### PR TITLE
Remove duplicated gradients

### DIFF
--- a/resources/views/livewire/link-settings/edit.blade.php
+++ b/resources/views/livewire/link-settings/edit.blade.php
@@ -42,8 +42,6 @@
                                   'from-blue-500 to-teal-700',
                                   'from-red-500 to-orange-600',
                                   'from-blue-500 to-purple-600',
-                                  'from-blue-500 to-teal-700',
-                                  'from-red-500 to-orange-600',
                                   'from-purple-500 to-pink-500',
                                   'from-indigo-500 to-lime-700',
                                   'from-yellow-600 to-blue-600',


### PR DESCRIPTION
This PR removes two duplicated gradients that were causing a bug when a duplicated one is clicked, the other one is also highlighted because of the repeated html IDs

![chrome-capture-2024-3-20](https://github.com/pinkary-project/pinkary.com/assets/86016347/c59efcb3-b42c-409c-bcf8-a537b6317213)
