### PR TITLE
Copy question URL to clipboard for browsers not supporting share

### DIFF
--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -116,6 +116,7 @@
                     <span class="mx-1">•</span>
                     <button
                         x-data="shareProfile"
+                        x-show="isVisible"
                         @click="share({
                                         url: '{{
                                             route('questions.show', [
@@ -124,6 +125,21 @@
                                             ])
                                         }}'
                                     })"
+                        class="text-slate-500 transition-colors hover:underline focus:outline-none"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4 transition-colors hover:text-slate-400"><path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" /></svg>
+                    </button>
+                    <button
+                        x-cloak
+                        x-data="copyUrl"
+                        x-show="isVisible"
+                        @click="copyToClipboard('{{
+                            route('questions.show', [
+                                'user' => $question->to->username,
+                                'question' => $question,
+                            ])
+                        }}')"
+                        type="button"
                         class="text-slate-500 transition-colors hover:underline focus:outline-none"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4 transition-colors hover:text-slate-400"><path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" /></svg>


### PR DESCRIPTION
This PR fixes an issue for browsers not supporting "navigation.share" when sharing a question.

Instead, it will copy the URL to the clipboard.