### PR TITLE
Replace `orWhere` with `whereAny`

### DIFF
--- a/app/Livewire/Users/Index.php
+++ b/app/Livewire/Users/Index.php
@@ -38,8 +38,8 @@ final class Index extends Component
      */
     private function usersByQuery(): Collection
     {
-        return User::where('name', 'like', "%{$this->query}%")
-            ->orWhere('username', 'like', "%{$this->query}%")
+        return User::query()
+            ->whereAny(['name', 'username'], 'like', "%{$this->query}%")
             ->withCount('questionsReceived')
             ->orderBy('questions_received_count', 'desc')->limit(10)->get();
     }


### PR DESCRIPTION
This PR replaces the existing `orWhere`s with the new Laravel 11's `whereAny`.