### PR TITLE
test: add missing `BrProviderParsable`  tests

### DIFF
--- a/app/Services/ParsableContentProviders/BrProviderParsable.php
+++ b/app/Services/ParsableContentProviders/BrProviderParsable.php
@@ -13,6 +13,6 @@ final readonly class BrProviderParsable implements ParsableContentProvider
      */
     public function parse(string $content): string
     {
-        return (string) preg_replace('/\n/', '</br>', $content);
+        return (string) preg_replace('/\n/', '<br>', $content);
     }
 }

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -2,6 +2,21 @@
 
 declare(strict_types=1);
 
+test('brs', function (string $content, string $parsed) {
+    $provider = new App\Services\ParsableContentProviders\BrProviderParsable();
+
+    expect($provider->parse($content))->toBe($parsed);
+})->with([
+    [
+        'content' => "Check this:\nHello, World!",
+        'parsed' => 'Check this:<br>Hello, World!',
+    ],
+    [
+        'content' => "Check this:\n\nHello, World!\n",
+        'parsed' => 'Check this:<br><br>Hello, World!<br>',
+    ],
+]);
+
 test('links', function (string $content, string $parsed) {
     $provider = new App\Services\ParsableContentProviders\LinkProviderParsable();
 


### PR DESCRIPTION
This PR adds missing tests for the `BrProviderParsable`.