### PR TITLE
Fix button label on create link component

### DIFF
--- a/resources/views/livewire/links/create.blade.php
+++ b/resources/views/livewire/links/create.blade.php
@@ -26,7 +26,7 @@
                 class="text-{{ $user->left_color }} border-{{ $user->left_color }}"
                 type="submit"
             >
-                {{ __('Send') }}
+                {{ __('Create') }}
             </x-primary-colorless-button>
             <button
                 @click="showLinksForm = false"


### PR DESCRIPTION
This PR fixes the `save` button on the create link component to display "Create" instead of "Save"

| Before | After|
-------|-------
|![image](https://github.com/pinkary-project/pinkary.com/assets/19756164/ed65fa01-ac59-409e-8fcc-8a21abae6ef0)| ![image](https://github.com/pinkary-project/pinkary.com/assets/19756164/c8417b6c-3b1f-4777-b3ff-d662f7224eb2)|
