### PR TITLE
fix: verified icon add missing width and height.

### DIFF
--- a/resources/views/livewire/users/index.blade.php
+++ b/resources/views/livewire/users/index.blade.php
@@ -41,7 +41,7 @@
                                     @if ($user->is_verified)
                                         <x-icons.verified
                                             :color="$user->right_color"
-                                            class="ml-1 mt-0.5 flex-shrink-0"
+                                            class="ml-1 mt-0.5 flex-shrink-0 h-4 w-4"
                                         />
                                     @endif
                                 </div>


### PR DESCRIPTION
This PR fixes the missing width and height for the verified icon:

![telegram-cloud-photo-size-4-6046273712145154418-y](https://github.com/pinkary-project/pinkary.com/assets/823088/f52ef599-0007-4eed-bd30-a9bc2fc9658c)