### PR TITLE
Remove overflow-hidden from guest layout

### DIFF
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -15,7 +15,7 @@
                 </div>
 
                 <div class="-mt-10 flex min-h-screen flex-col items-center justify-center sm:mx-2">
-                    <div class="w-full max-w-md overflow-hidden rounded-lg py-10 shadow-md">
+                    <div class="w-full max-w-md rounded-lg py-10 shadow-md">
                         {{ $slot }}
                     </div>
                 </div>


### PR DESCRIPTION
This PR removes the overflow hidden from guest layout, it causes a little issue on input focus and checkbox
![pinkary](https://github.com/pinkary-project/pinkary.com/assets/43938927/ec3fb484-401f-4074-8812-567bd7c22fb6)
