### PR TITLE
Add padding on smaller screens for the guest layout

### DIFF
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -15,7 +15,7 @@
                 </div>
 
                 <div class="-mt-10 flex min-h-screen flex-col items-center justify-center sm:mx-2">
-                    <div class="w-full max-w-md rounded-lg py-10 shadow-md">
+                    <div class="w-full max-w-md rounded-lg px-4 py-10 shadow-md sm:px-0">
                         {{ $slot }}
                     </div>
                 </div>


### PR DESCRIPTION
This PR introduces a `px-4` padding for smaller screens, which then resets to `px-0` at the `sm` breakpoint for the guest layout. The added padding aligns with the existing padding of the menu button, ensuring design consistency. 

This adjustment aims to improve readability on pages such as `confirm-password` and `reset-password`.

Before
![Group 2](https://github.com/pinkary-project/pinkary.com/assets/4650238/8fdb5fab-38db-4d57-b15d-a6fc88659492)

After
![Group 3](https://github.com/pinkary-project/pinkary.com/assets/4650238/8a0b54cd-3fa9-413f-b9a3-df983c57e6e4)
