### PR TITLE
Dispatch after commit

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -50,7 +50,7 @@ final readonly class ProfileController
 
         $user->save();
 
-        dispatch(new DownloadUserAvatar($user));
+        DownloadUserAvatar::dispatch($user)->afterCommit();
 
         session()->flash('flash-message', 'Profile updated.');
 


### PR DESCRIPTION
This PR proposes a minor but impactful enhancement to the way we dispatch the job for downloading user avatars. The current implementation immediately dispatches the job upon the update of a user's profile. This change introduces the use of Laravel's `afterCommit` method chained to the job dispatch method. By doing so, we ensure that the `DownloadUserAvatar` job is only dispatched after the database transaction is successfully committed. This approach enhances the reliability of the job dispatching process, ensuring that the job is not dispatched if the transaction fails, thus keeping our data in a consistent state.

**Benefits**

- **Reliability**: Ensures the job is only dispatched after the user profile update transaction is successfully committed, preventing the job from being dispatched if the transaction fails.

- **Consistency**: Helps maintain data consistency by avoiding scenarios where the avatar download job might run for a transaction that wasn't committed.

- **Best Practices**: Aligns with Laravel's recommended practices for dispatching jobs in scenarios involving database transactions.