### PR TITLE
Improved link parsing

### DIFF
--- a/app/Services/ParsableContentProviders/LinkProviderParsable.php
+++ b/app/Services/ParsableContentProviders/LinkProviderParsable.php
@@ -14,7 +14,7 @@ final readonly class LinkProviderParsable implements ParsableContentProvider
     public function parse(string $content): string
     {
         return (string) preg_replace_callback(
-            '/((https?:\/\/)?[\w\-._@:%\+~#=]{1,256}\.[a-z]{2,4}\b(\/[\w\-._@:%\+~#=\/]*)?)/i',
+            '/((https?:\/\/)?[\w\-._@:%\+~#=]{1,256}(\.[a-z]{2,})+\b(\/[\w\-._@:%\+~#=\/]*)?)/i',
             function (array $matches): string {
                 $url = preg_match('/^https?:\/\//', $matches[0]) ? $matches[0] : 'https://'.$matches[0];
                 $humanUrl = (string) preg_replace('/^https?:\/\//', '', $matches[0]);

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -27,6 +27,14 @@ test('links', function (string $content, string $parsed) {
         'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" target="_blank" href="https://example.com/">example.com</a>',
     ],
     [
+        'content' => 'https://example.media/',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" target="_blank" href="https://example.media/">example.media</a>',
+    ],
+    [
+        'content' => 'https://example.co.uk/',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" target="_blank" href="https://example.co.uk/">example.co.uk</a>',
+    ],
+    [
         'content' => 'Hello https://example.com',
         'parsed' => 'Hello <a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" target="_blank" href="https://example.com">example.com</a>',
     ],


### PR DESCRIPTION
This change makes sure TLDs like `.co.uk` and `.media` are matched as well.