### PR TITLE
Fix flash message overlapping navigation buttons

### DIFF
--- a/resources/views/livewire/flash-messages/show.blade.php
+++ b/resources/views/livewire/flash-messages/show.blade.php
@@ -1,5 +1,5 @@
 <div x-data>
-    <div id="flashMessageWrapper" class="fixed right-4 top-4 w-64 space-y-2"></div>
+    <div id="flashMessageWrapper" class="fixed right-4 top-4 w-64 space-y-2 -z-10"></div>
 
     @if (session('flash-message'))
         <div


### PR DESCRIPTION
- Added the -z-10 class to the flashMessageWrapper div to set a negative z-index value.
- This ensures that the flash message container is positioned behind other elements on the page, preventing it from overlapping and disabling the navigation links.

Code changes:
- Modified the flashMessageWrapper div in the resources/views/layouts/app.blade.php file:
  <div id="flashMessageWrapper" class="fixed right-4 top-4 w-64 space-y-2 -z-10"></div>