### PR TITLE
Fix the autofocus on the landing page by adding a condition to set focus on the component.

### DIFF
--- a/app/Livewire/Users/Index.php
+++ b/app/Livewire/Users/Index.php
@@ -20,6 +20,11 @@ final class Index extends Component
     public string $query = '';
 
     /**
+     * Indicates if the search input should be focused.
+     */
+    public bool $focusInput = false;
+
+    /**
      * Renders the component.
      */
     public function render(): View

--- a/resources/views/explore.blade.php
+++ b/resources/views/explore.blade.php
@@ -3,7 +3,7 @@
 
     <div class="flex flex-col items-center justify-center">
         <div class="w-full max-w-md overflow-hidden rounded-lg shadow-md">
-            <livewire:users.index />
+            <livewire:users.index focus-input="true"/>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/livewire/users/index.blade.php
+++ b/resources/views/livewire/users/index.blade.php
@@ -1,4 +1,4 @@
-<div class="mb-12 w-full px-2 text-slate-200" x-init="$refs.searchInput.focus()">
+<div class="mb-12 w-full px-2 text-slate-200">
     <div class="mb-8 w-full max-w-md">
         <div class="relative flex items-center py-1">
             <svg
@@ -16,11 +16,13 @@
                 ></path>
             </svg>
             <input
+                x-data="{ focusInput: {{ $focusInput }} }"
+                x-ref="searchInput"
+                x-init="if (focusInput) $refs.searchInput.focus()"
                 wire:model.live.debounce.500ms="query"
                 class="w-full rounded-2xl border border-slate-900 bg-gray-950 py-3 pl-14 pr-4 transition-all placeholder:text-slate-500"
                 type="text"
                 name="q"
-                x-ref="searchInput"
                 placeholder="Search for users..."
             />
         </div>


### PR DESCRIPTION
This PR set the autofocus to `false` by default and now is enabled only in the explore page passing a prop.

```php
    <livewire:users.index focus-input="true"/>
```

Fixes #57 