### PR TITLE
Vertical align verified badge

### DIFF
--- a/resources/views/livewire/links/index.blade.php
+++ b/resources/views/livewire/links/index.blade.php
@@ -20,10 +20,10 @@
             class="mx-auto h-24 w-24 rounded-full"
         />
 
-        <div class="items center flex justify-center">
+        <div class="items center flex justify-center items-center">
             <h2 class="text-2xl font-bold">{{ $user->name }}</h2>
             @if ($user->is_verified)
-                <x-icons.verified :color="$user->right_color" class="ml-1.5 mt-0.5 h-6 w-6" />
+                <x-icons.verified :color="$user->right_color" class="ml-1.5 h-6 w-6" />
             @endif
         </div>
 


### PR DESCRIPTION
This PR fixes the verified badge to be vertical aligned with the users's name

Before:
![current](https://github.com/pinkary-project/pinkary.com/assets/19756164/92a6e469-c8e7-493c-99dd-b3fe8e24e973)


After:
![expected](https://github.com/pinkary-project/pinkary.com/assets/19756164/27a9414d-2c07-47b1-8d0a-a1327c2bda55)

