### PR TITLE
fix: add missing `x-cloak` on the share button.

### DIFF
--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -145,6 +145,7 @@
                     </time>
                     <span class="mx-1">•</span>
                     <button
+                        x-cloak
                         x-data="shareProfile"
                         x-show="isVisible"
                         @click="share({


### PR DESCRIPTION
This PR fixes this:

![output](https://github.com/pinkary-project/pinkary.com/assets/823088/7ca08e49-6e8d-4685-b0c0-1bc86447b496)

Cheers