### PR TITLE
Add `break-words` to question answer

### DIFF
--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -103,7 +103,7 @@
                 @endif
             </div>
 
-            <p class="mt-3 text-slate-200 overflow-x-auto">
+            <p class="mt-3 text-slate-200 break-words">
                 {!! $question->answer !!}
             </p>
 


### PR DESCRIPTION
This allow to scroll the question answer horizontally.



Before:
![image](https://github.com/pinkary-project/pinkary.com/assets/19756164/2ba53982-b138-4d34-9f53-41883c95ecc1)


After:
![image](https://github.com/pinkary-project/pinkary.com/assets/19756164/f761c2c1-1fc9-44fe-a639-eaabcaab9198)

