### PR TITLE
Hide Home and Explore buttons on extra small screen resolutions

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -9,10 +9,16 @@
             </a>
         @else
             <a href="{{ route('home') }}" wire:navigate>
-                <x-primary-colorless-button>Home</x-primary-colorless-button>
+                <x-primary-colorless-button class="flex gap-2 justify-center items-center">
+                    <x-icons.home class="h-4 w-4" />
+                    <span class="sr-only sm:not-sr-only">Home</span>
+                </x-primary-colorless-button>
             </a>
             <a href="{{ route('explore') }}" wire:navigate>
-                <x-primary-colorless-button>Explore</x-primary-colorless-button>
+                <x-primary-colorless-button class="flex gap-2 justify-center items-center">
+                    <x-icons.magnifying-glass class="h-4 w-4" />
+                    <span class="sr-only sm:not-sr-only">Explore</span>
+                </x-primary-colorless-button>
             </a>
             <a href="{{ route('login') }}" wire:navigate>
                 <x-primary-button>Log In</x-primary-button>


### PR DESCRIPTION
This PR will resolve issue #105 by showing icons next to Home and Explore buttons. When viewport size goes below `sm` breakpoint, only icons will be shown.

Normal screens
![image](https://github.com/pinkary-project/pinkary.com/assets/8179000/c787b81a-e55e-42a7-97de-76b525efb3e7)

Small screens
![image](https://github.com/pinkary-project/pinkary.com/assets/8179000/0d8e85c3-78ae-4b46-851f-5309d4446a37)
