### PR TITLE
Fix: Local Test Failure Due to Hardcoded App URL

### DIFF
--- a/tests/Unit/Mail/PendingNotificationsTest.php
+++ b/tests/Unit/Mail/PendingNotificationsTest.php
@@ -33,7 +33,7 @@ test('content', function () {
     foreach ([
         '# Hello, '.$user->name.'!',
         "We've noticed you have 1 notification. You can view notifications by clicking the button below.",
-        'If you no longer wish to receive these emails, you can change your "Mail Preference Time" in your [profile settings](https://pinkary.com/profile).',
+        'If you no longer wish to receive these emails, you can change your "Mail Preference Time" in your [profile settings]('.config('app.url').'/profile).',
     ] as $line) {
         $mail->assertSeeInText($line);
     }


### PR DESCRIPTION
This PR addresses a bug that was causing local tests to fail when using the `.test` TLD that is given when running the project locally using Herd/Valet. The issue was due to a hardcoded app URL in `PendingNotificationsTest.php`.

Changes include:

- Modified the hardcoded app URL in `PendingNotificationsTest.php` to make it dynamic, allowing for local testing with different TLDs.

This fix ensures that the tests will pass regardless of the local development environment setup. Please review and provide any feedback.

<img width="908" alt="Screenshot 2024-04-02 at 10 57 59 pm" src="https://github.com/pinkary-project/pinkary.com/assets/112100521/f30e99ee-b955-441d-a8b7-f70c9a15d63f">
