### PR TITLE
Feat: Add Explore Link to Guest Dropdown Menu

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -70,6 +70,10 @@
                                 {{ __('About') }}
                             </x-dropdown-link>
 
+                            <x-dropdown-link :href="route('explore')">
+                                {{ __('Explore') }}
+                            </x-dropdown-link>
+
                             <x-dropdown-link :href="route('login')">
                                 {{ __('Log in') }}
                             </x-dropdown-link>


### PR DESCRIPTION
This PR introduces adds an "Explore" link to the dropdown menu for guests. This allows guests to easily navigate to the Explore page from any part of the website.

Changes include:

- Added a new link to the `resources/views/layouts/navigation.blade.php` file that points to the Explore page.

This feature enhances the user experience for guests by providing easy access to the Explore page.
Please review and provide any feedback.

<img width="257" alt="Screenshot 2024-04-02 at 11 22 54 pm" src="https://github.com/pinkary-project/pinkary.com/assets/112100521/da8fffe9-ba1b-4abd-8897-12fd2fa46b70">