### PR TITLE
Misc: Use a link icon instead of paper airplane on questions

### DIFF
--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -173,7 +173,7 @@
                         type="button"
                         class="text-slate-500 transition-colors hover:text-slate-400 focus:outline-none"
                     >
-                        <x-icons.paper-airplane class="h-4 w-4" />
+                        <x-icons.link class="size-4" />
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
The current icon for copying the direct link to a question isn't super obvious. This is just a small change to use the same `link` icon that is used elsewhere already.

**Before:**
![CleanShot 2024-04-04 at 20 21 39@2x](https://github.com/pinkary-project/pinkary.com/assets/41837763/217b56f7-27e2-47bc-a2b5-d5123a393b4c)

**After:**
![CleanShot 2024-04-04 at 20 22 04@2x](https://github.com/pinkary-project/pinkary.com/assets/41837763/1b5c8d42-7cfd-495e-9fa9-64dd837275ce)
