### PR TITLE
Refactor notifications to use named parameters

### DIFF
--- a/app/Livewire/LinkSettings/Edit.php
+++ b/app/Livewire/LinkSettings/Edit.php
@@ -57,7 +57,7 @@ final class Edit extends Component
         $user->update(['settings' => $validated]);
 
         $this->dispatch('link-settings.updated');
-        $this->dispatch('notification.created', 'Link settings updated.');
+        $this->dispatch('notification.created', message: 'Link settings updated.');
     }
 
     /**

--- a/app/Livewire/Links/Create.php
+++ b/app/Livewire/Links/Create.php
@@ -59,7 +59,7 @@ final class Create extends Component
         $this->url = '';
 
         $this->dispatch('link.created');
-        $this->dispatch('notification.created', 'Link created.');
+        $this->dispatch('notification.created', message: 'Link created.');
     }
 
     /**

--- a/app/Livewire/Links/Index.php
+++ b/app/Livewire/Links/Index.php
@@ -79,7 +79,7 @@ final class Index extends Component
 
         $link->delete();
 
-        $this->dispatch('notification.created', 'Link deleted.');
+        $this->dispatch('notification.created', message: 'Link deleted.');
     }
 
     /**

--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -92,7 +92,7 @@ final class Create extends Component
         $this->anonymously = $user->prefers_anonymous_questions;
 
         $this->dispatch('question.created');
-        $this->dispatch('notification.created', 'Question sent.');
+        $this->dispatch('notification.created', message: 'Question sent.');
     }
 
     /**

--- a/app/Livewire/Questions/Edit.php
+++ b/app/Livewire/Questions/Edit.php
@@ -44,7 +44,7 @@ final class Edit extends Component
 
         $this->answer = '';
 
-        $this->dispatch('notification.created', 'Question answered.');
+        $this->dispatch('notification.created', message: 'Question answered.');
         $this->dispatch('question.updated');
     }
 
@@ -61,7 +61,7 @@ final class Edit extends Component
             'is_reported' => true,
         ]);
 
-        $this->dispatch('notification.created', 'Question reported.');
+        $this->dispatch('notification.created', message: 'Question reported.');
         $this->dispatch('question.reported');
     }
 
@@ -70,7 +70,7 @@ final class Edit extends Component
      */
     public function ignore(): void
     {
-        $this->dispatch('notification.created', 'Question ignored.');
+        $this->dispatch('notification.created', message: 'Question ignored.');
 
         $this->dispatch('question.ignore', questionId: $this->questionId);
     }

--- a/app/Livewire/Questions/Show.php
+++ b/app/Livewire/Questions/Show.php
@@ -75,7 +75,7 @@ final class Show extends Component
         }
 
         if ($this->inIndex) {
-            $this->dispatch('notification.created', 'Question ignored.');
+            $this->dispatch('notification.created', message: 'Question ignored.');
 
             $this->dispatch('question.ignore', questionId: $this->questionId);
 

--- a/tests/Unit/Livewire/FlashMessages/ShowTest.php
+++ b/tests/Unit/Livewire/FlashMessages/ShowTest.php
@@ -9,12 +9,12 @@ test('displays flash message', function () {
 
     $component = Livewire::test(Show::class);
 
-    $component->dispatch('notification.created', 'Hello, world!');
+    $component->dispatch('notification.created', message: 'Hello, world!');
 
     $component->assertSee('Hello, world!');
     $component->assertDontSee('Goodbye, world!');
 
-    $component->dispatch('notification.created', 'Goodbye, world!');
+    $component->dispatch('notification.created', message: 'Goodbye, world!');
 
     $component->assertDontSee('Hello, world!');
     $component->assertSee('Goodbye, world!');
@@ -23,7 +23,7 @@ test('displays flash message', function () {
 test('flushes flash message', function () {
     $component = Livewire::test(Show::class);
 
-    $component->dispatch('notification.created', 'Hello, world!');
+    $component->dispatch('notification.created', message: 'Hello, world!');
 
     $component->assertSee('Hello, world!');
     $component->assertSee('Hello, world!');

--- a/tests/Unit/Livewire/LinkSettings/EditTest.php
+++ b/tests/Unit/Livewire/LinkSettings/EditTest.php
@@ -41,7 +41,7 @@ it('allows user to update link settings', function () {
     $component->call('update');
 
     $component->assertDispatched('link-settings.updated');
-    $component->assertDispatched('notification.created', 'Link settings updated.');
+    $component->assertDispatched('notification.created', message: 'Link settings updated.');
 
     $user->refresh();
 

--- a/tests/Unit/Livewire/Links/CreateTest.php
+++ b/tests/Unit/Livewire/Links/CreateTest.php
@@ -19,7 +19,7 @@ test('allows to create link', function () {
     $component->call('store');
 
     $component->assertDispatched('link.created');
-    $component->assertDispatched('notification.created', 'Link created.');
+    $component->assertDispatched('notification.created', message: 'Link created.');
 
     $user->refresh();
 
@@ -43,7 +43,7 @@ test('https is added to the URL', function () {
     $component->call('store');
 
     $component->assertDispatched('link.created');
-    $component->assertDispatched('notification.created', 'Link created.');
+    $component->assertDispatched('notification.created', message: 'Link created.');
 
     $user->refresh();
 

--- a/tests/Unit/Livewire/Questions/CreateTest.php
+++ b/tests/Unit/Livewire/Questions/CreateTest.php
@@ -56,7 +56,7 @@ test('store', function () {
     $component->assertSet('content', '');
     $component->assertSet('anonymously', true);
 
-    $component->assertDispatched('notification.created', 'Question sent.');
+    $component->assertDispatched('notification.created', message: 'Question sent.');
     $component->assertDispatched('question.created');
 
     $question = App\Models\Question::first();
@@ -187,7 +187,7 @@ test('store with user questions_preference set to public', function () {
     $component->assertSet('content', '');
     $component->assertSet('anonymously', false);
 
-    $component->assertDispatched('notification.created', 'Question sent.');
+    $component->assertDispatched('notification.created', message: 'Question sent.');
     $component->assertDispatched('question.created');
 
     $question = App\Models\Question::first();
@@ -217,7 +217,7 @@ test('store with user questions_preference set to anonymously', function () {
     $component->assertSet('content', '');
     $component->assertSet('anonymously', true);
 
-    $component->assertDispatched('notification.created', 'Question sent.');
+    $component->assertDispatched('notification.created', message: 'Question sent.');
     $component->assertDispatched('question.created');
 
     $question = App\Models\Question::first();
@@ -248,7 +248,7 @@ test('anonymous set back to user\'s preference after sending a question', functi
     $component->assertSet('content', '');
     $component->assertSet('anonymously', false);
 
-    $component->assertDispatched('notification.created', 'Question sent.');
+    $component->assertDispatched('notification.created', message: 'Question sent.');
     $component->assertDispatched('question.created');
 
     $question = App\Models\Question::first();

--- a/tests/Unit/Livewire/Questions/EditTest.php
+++ b/tests/Unit/Livewire/Questions/EditTest.php
@@ -83,7 +83,7 @@ test('ignore', function () {
 
     $component->call('ignore');
 
-    $component->assertDispatched('notification.created', 'Question ignored.');
+    $component->assertDispatched('notification.created', message: 'Question ignored.');
     $component->assertDispatched('question.ignore', questionId: $this->question->id);
 });
 

--- a/tests/Unit/Livewire/Questions/ShowTest.php
+++ b/tests/Unit/Livewire/Questions/ShowTest.php
@@ -100,7 +100,7 @@ test('ignore', function () {
     ]);
 
     $component->call('ignore');
-    $component->assertDispatched('notification.created', 'Question ignored.');
+    $component->assertDispatched('notification.created', message: 'Question ignored.');
     $component->assertDispatched('question.ignore');
 });
 


### PR DESCRIPTION
this PR added a named parameter to the notification.created event as suggested by Livewire.

It also helps to divide this https://github.com/pinkary-project/pinkary.com/pull/144 PR into 2 parts.