### PR TITLE
fix: avoid redeclaring timezone variable on app.blade.php

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -30,7 +30,7 @@
         @livewireScriptConfig
 
         <script>
-            const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
             if (timezone !== '{{ session()->get('timezone', 'UTC') }}') {
                 fetch('{{ route('timezone.update') }}', {


### PR DESCRIPTION
Prevent a variable redeclaration error from appearing when navigating through the menu across different sections of the application.

The error message that appeared up to now was:

`Uncaught SyntaxError: Identifier 'timezone' has already been declared`
