### PR TITLE
feat(timezone): using middleware for timezone assignment

### DIFF
--- a/app/Http/Middleware/TimezoneConfigAssignment.php
+++ b/app/Http/Middleware/TimezoneConfigAssignment.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final readonly class TimezoneConfigAssignment
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        /** @var string $timezone */
+        $timezone = session()->get('timezone', 'UTC');
+
+        date_default_timezone_set($timezone);
+
+        Carbon::setLocale($timezone);
+
+        config(['app.timezone' => $timezone]);
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Middleware\TimezoneConfigAssignment;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -12,7 +13,7 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->appendToGroup('web', TimezoneConfigAssignment::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/resources/views/livewire/links/index.blade.php
+++ b/resources/views/livewire/links/index.blade.php
@@ -68,7 +68,7 @@
 
                 <span>
                     Joined
-                    {{ $user->created_at->timezone(session()->get('timezone', 'UTC'))->format('M Y') }}
+                    {{ $user->created_at->format('M Y') }}
                 </span>
             </p>
         </div>

--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -146,12 +146,8 @@
                     </button>
                 </div>
                 <div class="flex items-center text-slate-500">
-                    <time datetime="{{ $question->answered_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}">
-                        {{
-                            $question->answered_at
-                                ->timezone(session()->get('timezone', 'UTC'))
-                                ->diffForHumans()
-                        }}
+                    <time datetime="{{ $question->answered_at->toIso8601String() }}">
+                        {{ $question->answered_at->diffForHumans() }}
                     </time>
                     <span class="mx-1">•</span>
                     <button


### PR DESCRIPTION
Instead of invoking the `timezone()` method of `Carbon` throughout the application, a middleware is implemented to handle this configuration on each request.