### PR TITLE
fix(user index): disable autofocus based on focusInput variable

### DIFF
--- a/app/Livewire/Users/Index.php
+++ b/app/Livewire/Users/Index.php
@@ -20,11 +20,6 @@ final class Index extends Component
     public string $query = '';
 
     /**
-     * Indicates if the search input should be focused.
-     */
-    public bool $focusInput = false;
-
-    /**
      * Renders the component.
      */
     public function render(): View

--- a/resources/views/livewire/users/index.blade.php
+++ b/resources/views/livewire/users/index.blade.php
@@ -13,9 +13,8 @@
             </svg>
 
             <x-text-input
-                x-data="{ focusInput: {{ $focusInput }} }"
                 x-ref="searchInput"
-                x-init="if (focusInput) $refs.searchInput.focus()"
+                x-init="$refs.searchInput.focus()"
                 wire:model.live.debounce.500ms="query"
                 name="q"
                 placeholder="Search for users..."


### PR DESCRIPTION
This commit disables the system that activates the focus of the user search based on the focusInput variable, as it was causing errors such as:

- `Alpine Expression Error: focusInput is not defined. Expression: "if (focusInput) $refs.searchInput.focus()"`
- `Uncaught ReferenceError: focusInput is not defined`