### PR TITLE
Fix: search input autofocus on landing page

### DIFF
--- a/app/Livewire/Users/Index.php
+++ b/app/Livewire/Users/Index.php
@@ -20,6 +20,11 @@ final class Index extends Component
     public string $query = '';
 
     /**
+     * Indicates if the search input should be focused.
+     */
+    public bool $focusInput = false;
+
+    /**
      * Renders the component.
      */
     public function render(): View

--- a/resources/views/explore.blade.php
+++ b/resources/views/explore.blade.php
@@ -3,7 +3,7 @@
 
     <div class="flex flex-col items-center justify-center">
         <div class="min-h-screen w-full max-w-md overflow-hidden rounded-lg shadow-md">
-            <livewire:users.index />
+            <livewire:users.index :focus-input="true" />
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/livewire/users/index.blade.php
+++ b/resources/views/livewire/users/index.blade.php
@@ -14,7 +14,7 @@
 
             <x-text-input
                 x-ref="searchInput"
-                x-init="$refs.searchInput.focus()"
+                x-init="if ($wire.focusInput) $refs.searchInput.focus()"
                 wire:model.live.debounce.500ms="query"
                 name="q"
                 placeholder="Search for users..."


### PR DESCRIPTION
This PR fixes #164, now the autofocus is only set on the explore page, preventing the landing page from loading in the middle of the content.

This PR also solves the console log alerts that @tomloprod mentioned. We can now conditionally use autofocus using the `focus-input` prop, as the component is now properly wired via `$wire.focusInput`, which was missing in the original implementation (PR #58).