### PR TITLE
fix: Allow to use mysql without breaking changes

### DIFF
--- a/database/migrations/2024_02_25_144346_create_likes_table.php
+++ b/database/migrations/2024_02_25_144346_create_likes_table.php
@@ -6,6 +6,7 @@ use App\Models\Question;
 use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -18,7 +19,10 @@ return new class extends Migration
         Schema::create('likes', function (Blueprint $table): void {
             $table->id();
             $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(Question::class)->constrained()->cascadeOnDelete();
+
+            DB::connection()->getDriverName() === 'mysql'
+                ? $table->foreignIdFor(Question::class)
+                : $table->foreignIdFor(Question::class)->constrained()->cascadeOnDelete();
 
             $table->unique(['user_id', 'question_id']);
 


### PR DESCRIPTION
As this is only for development purposes we don't need the the foreign key constraints for mysql.

The reason for this change is due the following error. 
![image](https://github.com/pinkary-project/pinkary.com/assets/53559175/ccf85fa2-b279-4449-b758-70250d92749d)