### PR TITLE
Feat: display details of the answered datetime using the 'title' attribute

### DIFF
--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -152,7 +152,11 @@
                     </button>
                 </div>
                 <div class="flex items-center text-slate-500">
-                    <time datetime="{{ $question->answered_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}">
+                    <time
+                        class="cursor-help"
+                        title="{{ $question->answered_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
+                        datetime="{{ $question->answered_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
+                    >
                         {{
                             $question->answered_at
                                 ->timezone(session()->get('timezone', 'UTC'))


### PR DESCRIPTION
Similar to what Twitter and other social networks do, display more details about the response date on hover (title):

![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/d87014ae-8f25-4e4d-b5cf-583621047d7c)
