### PR TITLE
hotfix(Home): fix responsive home menu

### DIFF
--- a/resources/views/components/home-menu.blade.php
+++ b/resources/views/components/home-menu.blade.php
@@ -1,38 +1,41 @@
 <div class="mb-8 flex justify-between space-x-2">
-
     <a
         href="{{ route('home.feed') }}"
         class="{{ request()->routeIs('home.feed') ? 'bg-pink-600 text-slate-100' : 'text-slate-500 hover:text-slate-100 bg-slate-900 ' }} whitespace-nowrap inline-flex flex-1 items-center justify-center rounded-md border border-transparent px-3 py-2 text-sm font-medium leading-4 transition duration-150 ease-in-out focus:outline-none"
         wire:navigate
+        wire:transition
     >
-        <x-icons.home class="mr-3 h-6 w-6" />
-        {{ __('Feed') }}
+        <x-icons.home class="min-[467px]:mr-3 h-6 w-6" />
+        <span class="hidden min-[467px]:inline">{{ __('Feed') }}</span>
     </a>
 
     <a
         href="{{ route('home.for_you') }}"
         class="{{ request()->routeIs('home.for_you') ? 'bg-pink-600 text-slate-100' : 'text-slate-500 hover:text-slate-100 bg-slate-900 ' }} whitespace-nowrap inline-flex flex-1 items-center justify-center rounded-md border border-transparent px-3 py-2 text-sm font-medium leading-4 transition duration-150 ease-in-out focus:outline-none"
         wire:navigate
+        wire:transition
     >
-        <x-icons.smile class="mr-3 h-6 w-6" />
-        {{ __('For you') }}
+        <x-icons.smile class="min-[467px]:mr-3 h-6 w-6" />
+        <span class="hidden min-[467px]:inline">{{ __('For you') }}</span>
     </a>
 
     <a
         href="{{ route('home.trending') }}"
         class="{{ request()->routeIs('home.trending') ? 'bg-pink-600 text-slate-100' : 'text-slate-500 hover:text-slate-100 bg-slate-900 ' }} whitespace-nowrap inline-flex flex-1 items-center justify-center rounded-md border border-transparent px-3 py-2 text-sm font-medium leading-4 transition duration-150 ease-in-out focus:outline-none"
         wire:navigate
+        wire:transition
     >
-        <x-icons.trending-solid color="currentColor" class="mr-3 h-6 w-6" />
-        {{ __('Trending') }}
+        <x-icons.trending-solid color="currentColor" class="min-[467px]:mr-3 h-6 w-6" />
+        <span class="hidden min-[467px]:inline">{{ __('Trending') }}</span>
     </a>
 
     <a
         href="{{ route('home.users') }}"
         class="{{ request()->routeIs('home.users') ? 'bg-pink-600 text-slate-100' : 'text-slate-500 hover:text-slate-100 bg-slate-900 ' }} whitespace-nowrap inline-flex flex-1 items-center justify-center rounded-md border border-transparent px-3 py-2 text-sm font-medium leading-4 transition duration-150 ease-in-out focus:outline-none"
         wire:navigate
+        wire:transition
     >
-        <x-icons.users class="mr-3 h-6 w-6" />
-        {{ __('Users') }}
+        <x-icons.users class="min-[467px]:mr-3 h-6 w-6" />
+        <span class="hidden min-[467px]:inline">{{ __('Users') }}</span>
     </a>
 </div>


### PR DESCRIPTION
The button texts are hidden at low resolutions to prevent the buttons from being cut off