### PR TITLE
Fix: Optimises factories for tests and hopefully for seeders if approved 👀

### DIFF
--- a/database/factories/LikeFactory.php
+++ b/database/factories/LikeFactory.php
@@ -25,8 +25,9 @@ final class LikeFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => User::factory(),
-            'question_id' => Question::factory(),
+            'user_id' => User::query()->inRandomOrder()->first()?->id ?? User::factory(),
+            'question_id' => Question::query()->inRandomOrder()->first()?->id ?? Question::factory(),
         ];
     }
 }
+    

--- a/database/factories/LinkFactory.php
+++ b/database/factories/LinkFactory.php
@@ -25,7 +25,7 @@ final class LinkFactory extends Factory
         return [
             'description' => $this->faker->sentence,
             'url' => $this->faker->url,
-            'user_id' => User::factory(),
+            'user_id' => User::query()->InRandomOrder()->first()?->id ?? User::factory(),
         ];
     }
 }

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -23,8 +23,8 @@ final class QuestionFactory extends Factory
     public function definition(): array
     {
         return [
-            'from_id' => User::factory(),
-            'to_id' => User::factory(),
+            'from_id' => User::query()->InRandomOrder()->first()?->id ?? User::factory(),
+            'to_id' => User::query()->InRandomOrder()->first()?->id ?? User::factory(),
             'content' => $this->faker->sentence,
             'anonymously' => $this->faker->boolean,
             'answer' => $this->faker->sentence,


### PR DESCRIPTION
This small PR enhances factories by eliminating redundant user entries. Instead of creating a new user for each question and like, factories can now check for existing users. This improves tests performance and future seeders.

Example Scenario:

**Previously**
1000 questions generates 2000 users.
10 likes for each question would create 10,000 users

**Now**
Initial user bank of 100 for example in local seeder
```php
$this->users = User::factory(100)->create();
```

1000 questions uses a random user
10 likes for each question uses random user
