### PR TITLE
[Fix] questions to be answered more than once

### DIFF
--- a/app/Livewire/Questions/Edit.php
+++ b/app/Livewire/Questions/Edit.php
@@ -49,7 +49,7 @@ final class Edit extends Component
             ->find($this->questionId);
 
         if (is_null($question)) {
-            $this->dispatch('notification.created', message: __('messages.error'));
+            $this->dispatch('notification.created', message: 'Sorry, something unexpected happened. Please try again.');
             $this->redirectRoute('profile.show', ['username' => $user->username], navigate: true);
 
             return;

--- a/tests/Unit/Livewire/Questions/EditTest.php
+++ b/tests/Unit/Livewire/Questions/EditTest.php
@@ -117,7 +117,7 @@ test('cannot answer a question that has already been answered', function () {
 
     $component->call('update');
 
-    $component->assertDispatched('notification.created', message: __('messages.error'));
+    $component->assertDispatched('notification.created', message: 'Sorry, something unexpected happened. Please try again.');
 
     $component->assertRedirect(route('profile.show', ['username' => $this->question->to->username]));
 });
@@ -135,7 +135,7 @@ test('cannot answer a question that has been reported or ignored', function () {
 
     $component->call('update');
 
-    $component->assertDispatched('notification.created', message: __('messages.error'));
+    $component->assertDispatched('notification.created', message: 'Sorry, something unexpected happened. Please try again.');
 
     $this->question->update([
         'is_reported' => false,
@@ -144,7 +144,7 @@ test('cannot answer a question that has been reported or ignored', function () {
 
     $component->call('update');
 
-    $component->assertDispatched('notification.created', message: __('messages.error'));
+    $component->assertDispatched('notification.created', message: 'Sorry, something unexpected happened. Please try again.');
 
     $component->assertRedirect(route('profile.show', ['username' => $this->question->to->username]));
 });


### PR DESCRIPTION
while answering one of my recent questions I made a typo!
then was going back and found the answer box again as I visited that twice anyhow.
then tried to answer again with a fixed typo, and it updated with a new answer.
it seems to be a bug!
the question cannot be answered more than once.

also added a check for reported and ignored questions.