### PR TITLE
Fix: Added zero check & humanize/abbreviate numbers rendered

### DIFF
--- a/resources/views/livewire/links/index.blade.php
+++ b/resources/views/livewire/links/index.blade.php
@@ -81,7 +81,7 @@
         <div class="mt-2 text-sm">
             <p class="text-slate-400">
                 <span>
-                    {{ $questionsReceivedCount }}
+                    {{ Number::abbreviate($questionsReceivedCount) }}
                     {{ str('Answer')->plural($questionsReceivedCount) }}
                 </span>
 
@@ -89,7 +89,7 @@
                     <span class="mx-1">•</span>
 
                     <span>
-                        {{ $user->views }} {{ str('View')->plural($user->views) }}
+                        {{ Number::abbreviate($user->views) }} {{ str('View')->plural($user->views) }}
                     </span>
                 @endif
 

--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -155,7 +155,7 @@
                         <span class="mx-1">•</span>
                         <x-icons.chart class="h-4 w-4" />
                         <p class="ml-1">
-                            {{ $question->views }} {{ str('view')->plural($question->views) }}
+                            {{ Number::abbreviate($question->views) }} {{ str('view')->plural($question->views) }}
                         </p>
                     @endif
                 </div>


### PR DESCRIPTION
As requested:
- added a conditional so views won't display if zero.
- Abbreviated the numbers to humanize the rendered number

<img width="470" alt="Screenshot 2024-04-17 at 12 11 32 pm" src="https://github.com/pinkary-project/pinkary.com/assets/112100521/fa23b7b1-d055-4873-b18a-ecda6b604be9">
<img width="470" alt="Screenshot 2024-04-17 at 12 12 35 pm" src="https://github.com/pinkary-project/pinkary.com/assets/112100521/c0c8f777-626d-4490-95d7-0f018de7394b">
