### PR TITLE
chore: remove unnecessary code and solve code coverage

### DIFF
--- a/app/Livewire/Questions/Edit.php
+++ b/app/Livewire/Questions/Edit.php
@@ -30,12 +30,6 @@ final class Edit extends Component
      */
     public function update(Request $request): void
     {
-        if (! auth()->check()) {
-            $this->redirectRoute('login', navigate: true);
-
-            return;
-        }
-
         $this->validate([
             'answer' => ['required', 'string', 'max:1000', new NoBlankCharacters],
         ]);


### PR DESCRIPTION
We remove a check for `! auth()->check()` that causes an unnecessary redirect since there's already a `QuestionPolicy` handling access control for that action (_in the rest of the methods in the same controller, it's not done with redirect, but rather delegated to the `QuestionPolicy`_).

This also resolves an issue with code coverage:

![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/d0697373-7275-4697-ba35-0115b068f3c6)

![image (3)](https://github.com/pinkary-project/pinkary.com/assets/7898894/24c1356d-9cbf-4fc5-8a20-4e8c6905ed0e)
