### PR TITLE
Add rel="me noopener" to profile links

### DIFF
--- a/resources/views/components/links/list-item.blade.php
+++ b/resources/views/components/links/list-item.blade.php
@@ -10,6 +10,7 @@
 <a
     href="{{ $link->url }}"
     target="_blank"
+    rel="me noopener"
     class="h-12 flex-1 items-center justify-center overflow-hidden px-4 font-bold text-white transition duration-300 ease-in-out"
 >
     <div class="flex h-full items-center justify-center">


### PR DESCRIPTION
Adds the `rel` attribute to profile links, with the following values:

- `me` - to support [Mastodon Verification](https://joinmastodon.org/verification)
- `noopener` - a security measure which prevents opened untrusted links from being able to access the opener (i.e. Pinkary). See: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noopener

Another one to consider add is `nofollow`:

> tells search engine spiders to ignore the link relationship. The nofollow relationship may indicate the current document's owner does not endorse the referenced document. It is often included by Search Engine Optimizers pretending their link farms are not spam pages.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#nofollow