### PR TITLE
Fix: Alignment issue on followers / following modals

### DIFF
--- a/resources/views/livewire/followers/index.blade.php
+++ b/resources/views/livewire/followers/index.blade.php
@@ -46,7 +46,7 @@
                                             />
                                         @endif
                                     </div>
-                                    <p class="truncate text-slate-500 transition-colors group-hover:text-slate-400">
+                                    <p class="truncate text-left text-slate-500 transition-colors group-hover:text-slate-400">
                                         {{ '@'.$user->username }}
                                     </p>
                                 </div>

--- a/resources/views/livewire/following/index.blade.php
+++ b/resources/views/livewire/following/index.blade.php
@@ -46,7 +46,7 @@
                                             />
                                         @endif
                                     </div>
-                                    <p class="truncate text-slate-500 transition-colors group-hover:text-slate-400">
+                                    <p class="truncate text-left text-slate-500 transition-colors group-hover:text-slate-400">
                                         {{ '@'.$user->username }}
                                     </p>
                                 </div>


### PR DESCRIPTION
Fix: Add text-left for text alignment issue on username of the followers / following modals

<img width="807" alt="Screenshot 2024-04-30 at 12 45 24 pm" src="https://github.com/pinkary-project/pinkary.com/assets/112100521/df986bcd-ab4e-4a60-8237-1a40c1ad8873">
