### PR TITLE
feat(Modals): add a close button to the modal component, in the top right corner.

### DIFF
--- a/resources/views/components/icons/close.blade.php
+++ b/resources/views/components/icons/close.blade.php
@@ -1,0 +1,10 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    class="h-6 w-6"
+    {{ $attributes }}
+>
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+</svg>

--- a/resources/views/components/modal-qr-code.blade.php
+++ b/resources/views/components/modal-qr-code.blade.php
@@ -1,6 +1,7 @@
 <x-modal
     name="show-qr-code"
     maxWidth="lg"
+    showCloseButton="false"
 >
     <div class="p-6">
         <img

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -2,6 +2,7 @@
     'name',
     'show' => false,
     'maxWidth' => '2xl',
+    'showCloseButton' => true,
 ])
 
 @php
@@ -17,6 +18,7 @@
 <div
     x-data="{
         show: @js($show),
+        showCloseButton: @js($showCloseButton),
         focusables() {
             // All focusable element types...
             let selector = 'a, button, input:not([type=\'hidden\']), textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
@@ -75,6 +77,14 @@
         x-transition:leave-start="translate-y-0 opacity-100 sm:scale-100"
         x-transition:leave-end="translate-y-4 opacity-0 sm:translate-y-0 sm:scale-95"
     >
+        <button
+            x-show="showCloseButton == true"
+            x-on:click="show = false"
+            class="absolute top-2 right-2 text-slate-500 text-xl focus:outline-none"
+        >
+            <x-icons.close />
+        </button>
+
         {{ $slot }}
     </div>
 </div>


### PR DESCRIPTION

![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/c79a4591-e85d-4ecc-bbec-dcc0595622bf)

Can be disabled using the `showCloseButton` param, for example, for the QR code modal window.





