### PR TITLE
fix: README.md remove pest from img alt and give accessible desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://pinkary.com/img/logo.svg" width="600" alt="PEST">
+    <img src="https://pinkary.com/img/logo.svg" width="600" alt="Illustration of Pinkary logo. The logo is composed of stylized white text spelling out 'Pinkary' with a pink dot at the end.">
 </p>
 
 ------


### PR DESCRIPTION
The logo in the README.md had the alt tag of the PEST logo. Replaced with a much more accessible description.