### PR TITLE
FIx: Styling updates on the modal lightbox

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -50,7 +50,7 @@
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
-    class="fixed inset-0 z-50 overflow-y-auto px-4 py-6 sm:px-0"
+    class="fixed inset-0 z-50 overflow-y-auto px-4 py-6 sm:px-0 bg-clip-padding backdrop-blur-sm backdrop-filter"
     style="display: {{ $show ? 'block' : 'none' }}"
 >
     <div
@@ -64,9 +64,8 @@
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
     >
-        <div class="absolute inset-0 bg-slate-500 opacity-75"></div>
+        <div class="absolute inset-0 bg-slate-500 bg-opacity-25"></div>
     </div>
-
     <div
         x-show="show"
         class="{{ $maxWidth }} mb-6 transform overflow-hidden rounded-lg bg-slate-950 shadow-xl transition-all sm:mx-auto sm:w-full"


### PR DESCRIPTION
I have added a glass morphism style background blur on the lightbox used by the modal to give better contrast and also give a more modern design look. 

Old & New screenshot:

<img width="983" alt="Screenshot 2024-05-01 at 2 47 21 pm" src="https://github.com/pinkary-project/pinkary.com/assets/112100521/6ea09412-c1a7-4fe1-aebc-bcbb917896e2">
<img width="983" alt="Screenshot 2024-05-01 at 2 46 51 pm" src="https://github.com/pinkary-project/pinkary.com/assets/112100521/8f9417a7-54fd-4bb8-8cad-eca6b3373cb7">
