### PR TITLE
Feat: question content length

### DIFF
--- a/app/Filament/Resources/QuestionResource.php
+++ b/app/Filament/Resources/QuestionResource.php
@@ -35,6 +35,7 @@ final class QuestionResource extends Resource
             ->defaultsort('created_at', 'desc')
             ->columns([
                 Tables\Columns\TextColumn::make('id')
+                    ->toggleable()
                     ->toggledHiddenByDefault()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('content')


### PR DESCRIPTION
added a limit for 40 characters on question content, and also added a tooltip if there is content of more than 40 characters.

end the add small bug fix in the id column 