### PR TITLE
Feature: Adding index to questions table foreign key to improve performance

### DIFF
--- a/database/migrations/2024_05_01_152116_add_from_id_and_to_id_indexes_to_questions_table.php
+++ b/database/migrations/2024_05_01_152116_add_from_id_and_to_id_indexes_to_questions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->index('from_id');
+            $table->index('to_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
For you section with 9k questions on database was about 4s only on the database query. Now it has improved to about 30ms adding indexes on the questions table related to foreign keys

<img width="553" alt="image" src="https://github.com/pinkary-project/pinkary.com/assets/57897024/47d70f0d-bf11-426d-949b-7a9cbb83014b">
