### PR TITLE
fix(phpstan): add bool type to isOpened

### DIFF
--- a/app/Livewire/Followers/Index.php
+++ b/app/Livewire/Followers/Index.php
@@ -24,7 +24,7 @@ final class Index extends Component
     /**
      * Indicates if the modal is opened.
      */
-    public $isOpened = false;
+    public bool $isOpened = false;
 
     /**
      * Renders the user's followers.

--- a/app/Livewire/Following/Index.php
+++ b/app/Livewire/Following/Index.php
@@ -24,7 +24,7 @@ final class Index extends Component
     /**
      * Indicates if the modal is opened.
      */
-    public $isOpened = false;
+    public bool $isOpened = false;
 
     /**
      * Renders the user's followers.


### PR DESCRIPTION
The tests couldn't run because PHPStan was failing due to two variables where a type (`bool`) wasn't specified.

![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/05ccce38-a61a-4307-a9bf-6c781cfb3185)
