### PR TITLE
feat(livewire): add strict types to livewire.php

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*


### PR DESCRIPTION
`declare(strict_types=1);` is added to the `livewire.php` file so that PHPStan doesn't fail.


