### PR TITLE
fix(twitter): replace code and html on shared question

### DIFF
--- a/resources/js/share-profile.js
+++ b/resources/js/share-profile.js
@@ -14,6 +14,11 @@ const shareProfile = () => ({
 
     twitter(options) {
         let text = options.question ? options.question + '%0A%0A' : ''
+
+        text = text
+            .replace(/<pre><code.*?>.*?<\/code><\/pre>/gs, "%0A%0A[👀 see the code on Pinkary 👀]%0A%0A")
+            .replace(/<\/?[^>]+(>|$)/g, "");
+
         window.open(
             `https://twitter.com/intent/tweet?text=${text}${options.message}:&url=${options.url}`,
             "_blank"


### PR DESCRIPTION
In the file `share-profile.js`, in the `twitter`method, two regex are applied:

- one to replace the code with a string like "see the code on Pinkary"
- and another regex to remove the HTML code.

## Original question
![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/037a59a7-8d5e-4e95-bcee-e19c65f27b4f)

## Before
![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/fff3991f-8ddc-4083-9e03-0713ed7a9095)

## After
![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/d25245a5-2c5b-4349-8408-de27c126621d)
