### PR TITLE
MentionProviderParsable: Fix invalid username mentions being linked

### DIFF
--- a/app/Services/ParsableContentProviders/MentionProviderParsable.php
+++ b/app/Services/ParsableContentProviders/MentionProviderParsable.php
@@ -14,7 +14,7 @@ final readonly class MentionProviderParsable implements ParsableContentProvider
     public function parse(string $content): string
     {
         return (string) preg_replace_callback(
-            '/(<a\s+[^>]*>.*?<\/a>)|@([^\s,.?!\/@<]+)/i',
+            '/(<a\s+[^>]*>.*?<\/a>)|@([a-z0-9_]+)/i',
             fn (array $matches): string => $matches[1] !== ''
                 ? $matches[1]
                 : '<a href="/@'.$matches[2].'" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@'.$matches[2].'</a>',

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____w31r4_________w31r4____.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____w31r4_________w31r4____.snap
@@ -1,0 +1,1 @@
+<a href="/@w31r4_" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@w31r4_</a>

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -182,7 +182,7 @@ test('mention', function (string $content) {
 })->with([
     ['content' => 'Hi @nunomaduro'],
     ['content' => '@nunomaduro hi'],
-    ['content' => '@w31r4_-NAME'],
+    ['content' => '@w31r4_'],
     ['content' => '@nunomaduro.'],
     ['content' => '@nunomaduro,'],
     ['content' => '@nunomaduro!'],


### PR DESCRIPTION
Closes #328.

The registration process limits usernames to letters, numbers and underscores, therefore the mention parsing in messages can be simplified to check for just those characters rather than anything outside of a fixed set of characters.