### PR TITLE
fix(share-profile): Use encodeURIComponent to avoid a 400 error on twitter

### DIFF
--- a/resources/js/share-profile.js
+++ b/resources/js/share-profile.js
@@ -13,13 +13,17 @@ const shareProfile = () => ({
     },
 
     twitter(options) {
-        let text = options.question ? options.question + '\n\n' : ''
+        let text = options.question ? options.question + '%0A%0A' : ''
 
-        text = encodeURIComponent(
-            text
-                .replace(/<pre><code.*?>.*?<\/code><\/pre>/gs, "\n\n[👀 see the code on Pinkary 👀]\n\n")
-                .replace(/<\/?[^>]+(>|$)/g, "")
-        );
+        text = text
+            .replace(/<pre><code.*?>.*?<\/code><\/pre>/gs, "%0A%0A[👀 see the code on Pinkary 👀]%0A%0A")
+            .replace(/<\/?[^>]+(>|$)/g, "")
+            .replace(/`/g, '')
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#039;/g, "'");
 
         window.open(
             `https://twitter.com/intent/tweet?text=${text}${options.message}:&url=${options.url}`,


### PR DESCRIPTION
The `twitter` method in `share-profile.js` is modified to filter characters like **'** and **`**