### PR TITLE
feat(TailwindPagination): Improve style of pagination buttons in modal windows

### DIFF
--- a/resources/views/vendor/livewire/simple-tailwind.blade.php
+++ b/resources/views/vendor/livewire/simple-tailwind.blade.php
@@ -21,27 +21,31 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                     </span>
                 @else
                     @if(method_exists($paginator,'getCursorName'))
-                        <button type="button" dusk="previousPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->previousCursor()->encode() }}" wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-950 border border-slate-500 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        <button type="button" dusk="previousPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->previousCursor()->encode() }}" wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-pink-500 bg-gray-950 border border-slate-500 leading-5 rounded-md hover:bg-pink-900/20 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:text-gray-700 transition ease-in-out duration-150">
                                 {!! __('pagination.previous') !!}
                         </button>
                     @else
                         <button
-                            type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-950 border border-slate-500 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                            type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-pink-500 bg-gray-950 border border-pink-500 leading-5 rounded-md hover:bg-pink-900/20 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:text-gray-700 transition ease-in-out duration-150">
                                 {!! __('pagination.previous') !!}
                         </button>
                     @endif
                 @endif
             </span>
 
+
+  {{--  class="inline-flex items-center px-4 py-2 border text-pink-500 border-pink-500 rounded-lg font-semibold text-xs tracking-widest hover:bg-pink-900/20 focus:outline-none focus:ring-0 focus:ring-offset-0 transition ease-in-out duration-150 text-blue-500 border-blue-500" --}}
+
+
             <span>
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     @if(method_exists($paginator,'getCursorName'))
-                        <button type="button" dusk="nextPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->nextCursor()->encode() }}" wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-gray-950 border border-slate-500 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        <button type="button" dusk="nextPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->nextCursor()->encode() }}" wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-pink-500 bg-gray-950 border border-pink-500 leading-5 rounded-md hover:bg-pink-900/20 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:text-pink-500 transition ease-in-out duration-150">
                                 {!! __('pagination.next') !!}
                         </button>
                     @else
-                        <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-gray-950 border border-slate-500 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-pink-500 bg-gray-950 border border-pink-500 leading-5 rounded-md hover:bg-pink-900/20 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:text-pink-500 transition ease-in-out duration-150">
                                 {!! __('pagination.next') !!}
                         </button>
                     @endif


### PR DESCRIPTION
So far, the pagination buttons had a gray color, even when the buttons are disabled because there are no more records (like the "previous" when you're on the first page or the "next" when you're on the last).

A style change has been applied to make it resemble the rest of Pinkary's buttons, setting a "pink" color on the active buttons.

### Before:
![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/fc035cf1-30cc-4fac-8b18-690f2207d82e)

### After:
![image](https://github.com/pinkary-project/pinkary.com/assets/7898894/d05dbd51-458c-4bd5-aeeb-9c39ebf873e9)



