### PR TITLE
fix: prevent livewire modal error on HTTP 419

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -41,6 +41,14 @@
                 if (timezone !== '{{ session()->get('timezone', 'UTC') }}') {
                     axios.post('{{ route('profile.timezone.update') }}', { timezone })
                 }
+
+                Livewire.hook('request', ({ uri, options, payload, respond, succeed, fail }) => {
+                    fail(({ status, content, preventDefault }) => {
+                        if (status === 419) {
+                            preventDefault()
+                        }
+                    })
+                })
             }
         </script>
     </body>


### PR DESCRIPTION
This way, people who have cookies disabled in their browser can use Pinkary normally without this modal window appearing.