### PR TITLE
fix: code sharing issue in twitter

### DIFF
--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -241,7 +241,7 @@
                                 x-on:click="
                                     twitter({
                                         url: '{{ route('questions.show', ['username' => $question->to->username, 'question' => $question]) }}',
-                                        question: '{{ $question->isSharedUpdate() ? $question->answer : $question->content }}',
+                                        question: '{{ str_replace("'", "\'", $question->isSharedUpdate() ? $question->answer : $question->content) }}',
                                         message: '{{ $question->isSharedUpdate() ? 'See it on Pinkary' : 'See response on Pinkary' }}',
                                     })
                                 "


### PR DESCRIPTION
It only fails if the content contains a single quote `'`, I just replaced it with `\'` so it won't break the string in JS. 