### PR TITLE
Fix: Update back link to use browser history

### DIFF
--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -3,10 +3,9 @@
         <div class="flex w-full max-w-md flex-col gap-12 overflow-hidden">
             <a
                 x-data="{
-                 hasHistory: history.length,
                  fallback: '{{ session('_previous.url', route('profile.show', ['username' => $question->to->username]))  }}',
                  back: function() {
-                        if (this.hasHistory > 1) {
+                        if (history.length > 1) {
                             history.back();
                         } else {
                             window.location.href = this.fallback;


### PR DESCRIPTION
Updated the back link to use browser history, which is already set by wire:navigate using [history.replaceState()](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)

EDIT: added a fallback using the `_previous.url` stored in the session, if the user hits refresh twice, or the history is not available. Also added profile as the default route if there is no previous url key in the session.


https://github.com/pinkary-project/pinkary.com/assets/112100521/faf5d22a-2b5b-48de-87bb-393a64d497e9