### PR TITLE
Fix: order of followers  following

### DIFF
--- a/app/Livewire/Followers/Index.php
+++ b/app/Livewire/Followers/Index.php
@@ -44,7 +44,7 @@ final class Index extends Component
                             $query->where('user_id', auth()->id());
                         },
                     ]);
-                })->latest('pivot_follower_id')->simplePaginate(10) : collect(),
+                })->latest('followers.id')->simplePaginate(10) : collect(),
         ]);
     }
 }

--- a/app/Livewire/Following/Index.php
+++ b/app/Livewire/Following/Index.php
@@ -40,7 +40,7 @@ final class Index extends Component
                 'following as is_follower' => function (Builder $query): void {
                     $query->where('user_id', auth()->id());
                 },
-            ])->latest('pivot_following_id')->simplePaginate(10) : collect(),
+            ])->latest('followers.id')->simplePaginate(10) : collect(),
         ]);
     }
 }


### PR DESCRIPTION
Right now if some old guys follow us on Pinkary it's hard to detect.
changing order with `followers`.`id.` to get the latest followers on top.