### PR TITLE
fix: title-of-page-containing-answer

### DIFF
--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -145,7 +145,7 @@
     />
 
     @if ($answer)
-        <title>{{ $question->to->name }}: "{{ $answer }}" / Pinkary</title>
+        <title>{{ $question->to->name }}: "{!! $answer !!}" / Pinkary</title>
         <meta
             property="og:title"
             content='{{ $ogTitle }}'


### PR DESCRIPTION
## before 
![image](https://github.com/pinkary-project/pinkary.com/assets/53343069/5fa86352-b224-46d9-a772-7b71068184d3)
## After
![image](https://github.com/pinkary-project/pinkary.com/assets/53343069/7c21adbd-508b-4671-b7a1-a1c522fdf7eb)
