### PR TITLE
Fix: Add titles to feed buttons.

### DIFF
--- a/resources/views/components/home-menu.blade.php
+++ b/resources/views/components/home-menu.blade.php
@@ -2,6 +2,7 @@
     <a
         href="{{ route('home.feed') }}"
         class="{{ request()->routeIs('home.feed') ? 'bg-pink-600 text-slate-100' : 'text-slate-500 hover:text-slate-100 bg-slate-900 ' }} inline-flex flex-1 items-center justify-center whitespace-nowrap rounded-md border border-transparent px-3 py-2 text-sm font-medium leading-4 transition duration-150 ease-in-out focus:outline-none"
+        title="{{ __('Feed') }}"
         wire:navigate
         wire:transition
     >
@@ -13,6 +14,7 @@
     <a
         href="{{ route('home.for_you') }}"
         class="{{ request()->routeIs('home.for_you') ? 'bg-pink-600 text-slate-100' : 'text-slate-500 hover:text-slate-100 bg-slate-900 ' }} inline-flex flex-1 items-center justify-center whitespace-nowrap rounded-md border border-transparent px-3 py-2 text-sm font-medium leading-4 transition duration-150 ease-in-out focus:outline-none"
+        title="{{ __('For you') }}"
         wire:navigate
         wire:transition
     >
@@ -24,6 +26,7 @@
     <a
         href="{{ route('home.trending') }}"
         class="{{ request()->routeIs('home.trending') ? 'bg-pink-600 text-slate-100' : 'text-slate-500 hover:text-slate-100 bg-slate-900 ' }} inline-flex flex-1 items-center justify-center whitespace-nowrap rounded-md border border-transparent px-3 py-2 text-sm font-medium leading-4 transition duration-150 ease-in-out focus:outline-none"
+        title="{{ __('Trending') }}"
         wire:navigate
         wire:transition
     >
@@ -37,6 +40,7 @@
     <a
         href="{{ route('home.users') }}"
         class="{{ request()->routeIs('home.users') ? 'bg-pink-600 text-slate-100' : 'text-slate-500 hover:text-slate-100 bg-slate-900 ' }} inline-flex flex-1 items-center justify-center whitespace-nowrap rounded-md border border-transparent px-3 py-2 text-sm font-medium leading-4 transition duration-150 ease-in-out focus:outline-none"
+        title="{{ __('Search') }}"
         wire:navigate
         wire:transition
     >


### PR DESCRIPTION
Add titles to feed buttons for better accessibility on small viewports & screen readers.
Doesn't fix the issue for touch screens, however users on a touch screen device have the uri, in the address bar.

https://github.com/pinkary-project/pinkary.com/assets/112100521/9da656c4-d150-4213-a31b-62605d44f24b

