### PR TITLE
Fix: Update snapshots

### DIFF
--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set____Hi__nunomaduro______Hi__nunomaduro__.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set____Hi__nunomaduro______Hi__nunomaduro__.snap
@@ -1,1 +1,1 @@
-Hi <a href="/@nunomaduro" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>
+Hi <a href="/@nunomaduro" data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro___.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro___.snap
@@ -1,1 +1,1 @@
-<a href="/@nunomaduro" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>.
+<a href="/@nunomaduro" data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>.

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro_____2.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro_____2.snap
@@ -1,1 +1,1 @@
-<a href="/@nunomaduro" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>,
+<a href="/@nunomaduro" data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>,

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro_____3.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro_____3.snap
@@ -1,1 +1,1 @@
-<a href="/@nunomaduro" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>!
+<a href="/@nunomaduro" data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>!

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro_____4.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro_____4.snap
@@ -1,1 +1,1 @@
-<a href="/@nunomaduro" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>?
+<a href="/@nunomaduro" data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>?

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro_____5.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro________nunomaduro_____5.snap
@@ -1,1 +1,1 @@
-<a href="/@nunomaduro" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>/
+<a href="/@nunomaduro" data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a>/

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro_hi_______nunomaduro_hi__.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____nunomaduro_hi_______nunomaduro_hi__.snap
@@ -1,1 +1,1 @@
-<a href="/@nunomaduro" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a> hi
+<a href="/@nunomaduro" data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@nunomaduro</a> hi

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____w31r4___NAME_______w31r4___NAME__.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____w31r4___NAME_______w31r4___NAME__.snap
@@ -1,1 +1,0 @@
-<a href="/@w31r4_-NAME" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@w31r4_-NAME</a>

--- a/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____w31r4_________w31r4____.snap
+++ b/tests/.pest/snapshots/Unit/Services/ContentProvidersTest/mention_with_data_set_____w31r4_________w31r4____.snap
@@ -1,1 +1,1 @@
-<a href="/@w31r4_" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@w31r4_</a>
+<a href="/@w31r4_" data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" wire-navigate>@w31r4_</a>


### PR DESCRIPTION
This PR updates the Pest snapshots so the expected data is inline with the new dataset used to make the card clickable allowing the test to pass.