### PR TITLE
Fix: remove obsolete test

### DIFF
--- a/tests/Unit/Livewire/Questions/ShowTest.php
+++ b/tests/Unit/Livewire/Questions/ShowTest.php
@@ -322,18 +322,3 @@ test('pinnable', function () {
 
     $component->assertSee('Pinned');
 });
-
-test('comment', function () {
-    $question = Question::factory()->create();
-
-    $component = Livewire::test(Show::class, [
-        'questionId' => $question->id,
-    ]);
-
-    $component->call('comment');
-
-    $component->assertRedirect(route('questions.show', [
-        'username' => $question->to->username,
-        'question' => $question->id,
-    ]));
-});


### PR DESCRIPTION
Fixes the failing obsolete test, due to method removed in previous PR @MrPunyapal 

<img width="718" alt="Screenshot 2024-07-12 at 1 36 21 PM" src="https://github.com/user-attachments/assets/cf5929b9-f92d-479a-bc75-a430cca194ac">
