### PR TITLE
Use pointer cursor styling for back button of questions.show

### DIFF
--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -13,7 +13,7 @@
                     }
                  }"
                 x-on:click.prevent="back()"
-                class="flex text-slate-400 hover:underline"
+                class="flex text-slate-400 hover:underline cursor-pointer"
             >
                 <x-icons.chevron-left class="h-6 w-6" />
                 <span>Back</span>


### PR DESCRIPTION
It seems like most links/actions are using the pointer cursor, and I noticed the `< Back` link of `questions.show` didn't incorporate this into its styling so this PR adds it.

I know, I know - an incredible contribution. 😅  