### PR TITLE
feat: Add question placeholder

### DIFF
--- a/app/Livewire/Questions/Show.php
+++ b/app/Livewire/Questions/Show.php
@@ -194,6 +194,46 @@ final class Show extends Component
     }
 
     /**
+     * Get the placeholder for the component.
+     */
+    public function placeholder(): string
+    {
+        return <<<'HTML'
+            <article class="block">
+                <div class="animate-pulse group p-4 mt-3 rounded-2xl bg-slate-900">
+                    <div class="flex items center justify-between">
+                        <div class="flex items center w-full">
+                            <div class="flex-shrink-0 mr-3">
+                                <div class="w-10 h-10 bg-slate-700 rounded-full"></div>
+                            </div>
+                            <div class="flex flex-col">
+                                <div class="w-20 h-2 mt-2 bg-slate-700 rounded"></div>
+                                <div class="w-16 h-2 mt-2.5 bg-slate-700 rounded"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex-column justify-start w-full py-1">
+                        <div class="h-2 w-10/12 bg-slate-700 my-3 rounded"></div>
+                        <div class="h-2 bg-slate-700 my-3 rounded"></div>
+                        <div class="h-2 w-32 bg-slate-700 my-3 rounded"></div>
+                    </div>
+                    <div class="flex items-center justify-between w-full">
+                        <div class="flex items-start">
+                            <div class="w-4 h-4 bg-slate-700 rounded-full"></div>
+                            <div class="w-4 h-4 bg-slate-700 rounded-full ml-2"></div>
+                            <div class="w-4 h-4 bg-slate-700 rounded-full ml-2"></div>
+                        </div>
+                        <div class="flex items-end">
+                            <div class="w-16 h-2 my-1 bg-slate-700 rounded"></div>
+                            <div class="w-4 h-4 bg-slate-700 rounded-full ml-2"></div>
+                        </div>
+                    </div>
+                </div>
+            </article>
+        HTML;
+    }
+
+    /**
      * Render the component.
      */
     public function render(): View


### PR DESCRIPTION
This PR adds a placeholder to the Questions Show Livewire component, that will be used, when the component is lazy-loaded.

<img width="474" alt="placeholder" src="https://github.com/user-attachments/assets/da0ae545-a615-488a-92c2-776ceb9f2c18">
