### PR TITLE
feat: Add line below parent

### DIFF
--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -34,8 +34,8 @@
 
             @foreach($parentQuestions as $parentQuestion)
                 <livewire:questions.show :questionId="$parentQuestion->id" :in-thread="false" />
-                <div class="relative -mt-11 -mb-14 h-10">
-                    <span class="absolute left-8 h-full w-1.5 rounded-full bg-slate-700 opacity-75" aria-hidden="true"></span>
+                <div class="relative -mt-11 -mb-14 h-14">
+                    <span class="absolute left-8 h-full w-1.5 rounded-full bg-slate-700" aria-hidden="true"></span>
                 </div>
             @endforeach
 


### PR DESCRIPTION
This PR add a little line below any parent, when viewing a specific post/question, being a reply to another post.

The intension is to indicate a relation between the posts/questions, like it's also done on twitter.

### Before:

<img width="485" alt="before" src="https://github.com/user-attachments/assets/10607c45-8280-41de-9c29-60f5493eda8f">


### After:

<img width="500" alt="after" src="https://github.com/user-attachments/assets/7219fe24-6439-4ccc-b6bb-4705290f8a79">
