### PR TITLE
Fix: issue with long code blocks

### DIFF
--- a/resources/js/copy-code.js
+++ b/resources/js/copy-code.js
@@ -50,8 +50,6 @@ const copyCode = () => ({
             const button = document.createElement('button');
             const setupButton = () => {
                 button.classList.add(
-                    'size-7',
-                    'items-center',
                     'opacity-0',
                     'group-hover/code:opacity-100',
                     'group-hover/code:bg-opacity-50',


### PR DESCRIPTION
Long code blocks were causing the item to scroll to the left.

This was the best solution:

https://github.com/user-attachments/assets/57825435-c891-4211-97d7-7ffa54182b4b

