### PR TITLE
Disable login button on submit

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -2,6 +2,7 @@
     <form
         method="POST"
         action="{{ route('login') }}"
+        onsubmit="event.submitter.disabled = true"
     >
         @csrf
 


### PR DESCRIPTION
I use 1Password... they recently started doing auto-login... but i can't get out of the habit of hitting return or clicking the login button... as it's not disabled, I then often get the expired page
<img width="932" alt="Screenshot 2024-07-17 at 13 25 18" src="https://github.com/user-attachments/assets/7af0d6e7-071e-41a2-8ce0-c2b7daed4c8f">

This small change would go some way to preventing that