### PR TITLE
Fix: Empty string seen as unanswered question

### DIFF
--- a/app/Services/ParsableContentProviders/ImageProviderParsable.php
+++ b/app/Services/ParsableContentProviders/ImageProviderParsable.php
@@ -16,13 +16,17 @@ final readonly class ImageProviderParsable implements ParsableContentProvider
     {
         return (string) preg_replace_callback(
             '/!\[(.*?)\]\((.*?)\)/',
-            static function (array $match): string {
+            static function (array $match) use ($content): string {
                 $altText = preg_replace('/\.(jpg|jpeg|png|gif)$/i', '', $match[1]);
 
                 $disk = Storage::disk('public');
 
                 if (! $disk->exists($match[2])) {
-                    return '...';
+                    $tag = "![{$match[1]}]({$match[2]})";
+                    if ($tag === $content) {
+                        return '...';
+                    }
+                    return '';
                 }
 
                 $url = $disk->url($match[2]);

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -224,4 +224,8 @@ test('image does not exists', function () {
     $content = '![](images/imagesdoesnotexists.png)';
 
     expect($provider->parse($content))->toBe('...');
+
+    $content = 'other content ![](images/imagesdoesnotexists.png)';
+
+    expect($provider->parse($content))->toBe('other content ');
 });


### PR DESCRIPTION
When image doesn't exist when we parse, if add an empty string & there is no other text "content" in the property, our other logic will think it's an unanswered question.

To fix this, I have returned '...' if there is no other content & an empty string **only** if there is more content other than the markdown.

<img width="698" alt="Screenshot 2024-07-21 at 10 16 37 AM" src="https://github.com/user-attachments/assets/94e9db6f-aa8b-464b-979d-05bd7e979cf1">


https://github.com/user-attachments/assets/d6140248-e97d-47a7-9d19-88cbafd10841



