### PR TITLE
Remove overflow-hidden from questions.show container

### DIFF
--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <div class="flex flex-col items-center py-10">
-        <div class="flex w-full max-w-md flex-col gap-12 overflow-hidden"
+        <div class="flex w-full max-w-md flex-col gap-12"
              x-data
              x-init="document.getElementById('q-{{ $question->id }}').scrollIntoView();">
             <a


### PR DESCRIPTION
With the new autocomplete feature, we need to permit some overflow so that results aren't clipped by the container.

It's hard to tell, but this _might_ also relate to #429...?

_Before_
![problem](https://github.com/user-attachments/assets/89230eb2-0e96-4926-9001-06779431b2b3)

_After_
![fixed](https://github.com/user-attachments/assets/c051dc6a-a95c-4791-9480-dfec3be79e7a)
