### PR TITLE
feat: remember posts

### DIFF
--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -148,6 +148,14 @@ final class Create extends Component
         return $this->isSharingUpdate ? 1000 : 255;
     }
 
+    #[Computed]
+    public function draftKey(): string
+    {
+        return $this->parentId !== null && $this->parentId !== '' && $this->parentId !== '0'
+            ? "reply_{$this->parentId}"
+            : 'post_new';
+    }
+
     /**
      * Refresh the component.
      */

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/typography": "^0.5.12",
         "alpinejs-notify": "^1.0.3",
+        "autosize": "^6.0.1",
         "autoprefixer": "^10.4.19",
         "axios": "^1.6.8",
         "highlight.js": "^11.9.0",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,5 @@
 import './bootstrap'
-
+import autosize from 'autosize';
 import focus from '@alpinejs/focus'
 import notifications from 'alpinejs-notify'
 import Sortable from 'sortablejs'
@@ -26,15 +26,10 @@ Alpine.directive('sortable', (el) => {
 })
 
 Alpine.directive('autosize', (el) => {
-    const offset = (el.offsetHeight - el.clientHeight) + 8
-    const resize = () => {
-        el.style.height = 'auto';
-        el.style.height = el.scrollHeight + offset + 'px';
-    };
-
-    el.addEventListener('input', resize);
-    el.resize = resize;
-})
+    if (el) {
+        autosize(el);
+    }
+});
 
 import { shareProfile } from './share-profile.js'
 Alpine.data('shareProfile', shareProfile)

--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -14,16 +14,29 @@
                 maxFileSize = {{ $this->maxFileSize }};
             }'
             class="relative group/menu">
-            <x-textarea
-                wire:model="content"
-                placeholder="{{ $this->placeholder }}"
-                maxlength="{{ $this->maxContentLength }}"
-                rows="3"
-                required
-                x-autosize
-                x-ref="content"
-            />
+                <div x-data="{ content: $persist($wire.entangle('content')).as('{{ $this->draftKey }}') }">
+                    <x-textarea
+                        x-model="content"
+                        placeholder="{{ $this->placeholder }}"
+                        maxlength="{{ $this->maxContentLength }}"
+                        rows="3"
+                        required
+                        x-autosize
+                        x-ref="content"
+                    />
+                </div>
 
+                <div class="absolute top-0 right-0 mt-2 mr-2 group-hover/menu:inline-block hidden">
+                    <button
+                        title="Upload an image"
+                        x-ref="imageButton"
+                        :disabled="uploading || images.length >= uploadLimit"
+                        class="rounded-lg bg-slate-800 text-sm text-slate-400 p-1.5 hover:text-pink-500"
+                        :class="{'cursor-not-allowed text-pink-500': uploading || images.length >= uploadLimit}"
+                    >
+                        <x-heroicon-o-camera class="h-5 w-5"/>
+                    </button>
+                </div>
             <div
                 class="absolute top-0 right-0 mt-2 mr-2 group-hover/menu:inline-block hidden">
                 <button title="Upload an image" x-ref="imageButton"


### PR DESCRIPTION
Imagine spending 10 minutes writing a post and then losing it? This could significantly decrease the user experience.
So what we do, is similar to how Linear handles this, is we remember it for you.

The thing is, a user does not want their reply on a specific comment with a different comment, so we have to remember it by post. If you're writing a new post, we just want to remember the new post.

Now, imagine you're writing a long post, there is this important use case you do want to remember the entire post and have it autosized, this is what we do now.

While working on this I did notice some slow rendering with the UI, but I suppose this must be because its extremely fast on local servers and I expect this not to be visible on production. One way we could counter this is by using placeholders on our replies.

I also used the autosize npm package which was a more suitable solution as it also accounts for resizing on initial load, some annoying edge cases and even takes into consideration when using a placeholder and accounting for the height it takes.

I've created a Loom where you can see the magic in action. 

Let me know if you guys have any suggestions, questions or feedback. I'd love to hear them.

Be careful if you have epilepsy, I'll turn on paint flashing at the end to show the rendering of DOM nodes.
https://www.loom.com/share/5a3a0e55a16e482db87771dd80c11221?sid=8d573565-d69e-4c93-9cf6-b07f6a4f8bf8