### PR TITLE
Feat(trending) make trending algo tunable; strftime() fix

### DIFF
--- a/app/Queries/Feeds/TrendingQuestionsFeed.php
+++ b/app/Queries/Feeds/TrendingQuestionsFeed.php
@@ -10,19 +10,46 @@ use Illuminate\Database\Eloquent\Builder;
 final readonly class TrendingQuestionsFeed
 {
     /**
+     * The likes bias for the trending feed.
+     */
+    private const int LIKES_BIAS = 1;
+
+    /**
+     * The comments bias for the trending feed.
+     */
+    private const int COMMENTS_BIAS = 1;
+
+    /**
+     * The time bias for the trending feed.
+     */
+    private const int TIME_BIAS = 86400;
+
+    /**
+     * The max days since posted for the trending feed.
+     */
+    private const int MAX_DAYS_SINCE_POSTED = 7;
+
+    /**
      * Get the query builder for the feed.
      *
      * @return Builder<Question>
      */
     public function builder(): Builder
     {
+        $likesBias = self::LIKES_BIAS;
+        $commentsBias = self::COMMENTS_BIAS;
+        $timeBias = self::TIME_BIAS;
+        $maxDaysSincePosted = self::MAX_DAYS_SINCE_POSTED;
+
         return Question::query()
-            ->withCount('likes')
-            ->where('likes_count', '>', 1)
-            ->orderByDesc('likes_count')
+            ->withCount('likes', 'children')
+            ->orderByRaw(<<<SQL
+                (((likes_count * {$likesBias} + 1.0) * (children_count * {$commentsBias} + 1.0))
+                / (strftime('%s') - strftime('%s', answer_created_at) + {$timeBias} + 1.0)) desc
+                SQL,
+            )
             ->where('is_reported', false)
             ->where('is_ignored', false)
-            ->where('answer_created_at', '>=', now()->subDays(7))
-            ->limit(10);
+            ->where('answer_created_at', '>=', now()->subDays($maxDaysSincePosted));
     }
 }

--- a/tests/Unit/Feeds/TrendingQuestionsTest.php
+++ b/tests/Unit/Feeds/TrendingQuestionsTest.php
@@ -26,18 +26,18 @@ it('render questions with right conditions', function () {
     expect($builder->get()->count())->toBe(1);
 });
 
-it('do not render questions without likes', function () {
+it('will render questions without likes or comments posted now', function () {
     $user = User::factory()->create();
 
     Question::factory()->create([
         'from_id' => $user->id,
         'to_id' => $user->id,
-        'answer_created_at' => now()->subDays(12),
+        'answer_created_at' => now(),
     ]);
 
     $builder = (new TrendingQuestionsFeed())->builder();
 
-    expect($builder->get()->count())->toBe(0);
+    expect($builder->get()->count())->toBe(1);
 });
 
 it('do not render questions older than 7 days', function () {

--- a/tests/Unit/Livewire/Home/TrendingTest.php
+++ b/tests/Unit/Livewire/Home/TrendingTest.php
@@ -147,4 +147,4 @@ test('renders trending questions order by trending score', function () {
         'trending question 2',
     ]);
     $component->assertDontSee('trending question 8');
-})->todo();
+});


### PR DESCRIPTION
Handles the revert by converting the `unixepoch()` function to `strftime('%s')`.

Also saw a test in `TrendingQuestionsTest` that wasn't accurate, so I updated it and altered it slightly to represent the new algo.

![image](https://github.com/user-attachments/assets/1410e6c3-a3ce-40de-972a-fbe98bc83e04)
![image](https://github.com/user-attachments/assets/92ea1fdf-b36d-4fe1-91e4-b9300bb923b7)
![image](https://github.com/user-attachments/assets/10b35b41-1714-4f86-9887-e6ed4c06f611)
![image](https://github.com/user-attachments/assets/ea4e7370-744a-46b6-a838-2f159295507b)
