### PR TITLE
Feat(hashtags) add #hashtag highlighting

### DIFF
--- a/app/Services/ParsableContent.php
+++ b/app/Services/ParsableContent.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Contracts\Services\ParsableContentProvider;
 use App\Services\ParsableContentProviders\BrProviderParsable;
 use App\Services\ParsableContentProviders\CodeProviderParsable;
+use App\Services\ParsableContentProviders\HashtagProviderParsable;
 use App\Services\ParsableContentProviders\ImageProviderParsable;
 use App\Services\ParsableContentProviders\LinkProviderParsable;
 use App\Services\ParsableContentProviders\MentionProviderParsable;
@@ -26,6 +27,7 @@ final readonly class ParsableContent
         BrProviderParsable::class,
         LinkProviderParsable::class,
         MentionProviderParsable::class,
+        HashtagProviderParsable::class,
     ])
     {
         //

--- a/app/Services/ParsableContentProviders/HashtagProviderParsable.php
+++ b/app/Services/ParsableContentProviders/HashtagProviderParsable.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ParsableContentProviders;
+
+use App\Contracts\Services\ParsableContentProvider;
+
+final readonly class HashtagProviderParsable implements ParsableContentProvider
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function parse(string $content): string
+    {
+        return (string) preg_replace_callback(
+            '/(<a\s+[^>]*>.*?<\/a>)|#([a-z0-9_]+)/i',
+            fn (array $matches): string => $matches[1] !== ''
+                ? $matches[1]
+                : '<span class="text-blue-500">#'.$matches[2].'</span>',
+            $content
+        );
+    }
+}

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -229,3 +229,50 @@ test('image does not exists', function () {
 
     expect($provider->parse($content))->toBe('other content ');
 });
+
+test('hashtags', function (string $content, string $parsed) {
+    $provider = new App\Services\ParsableContentProviders\HashtagProviderParsable();
+
+    expect($provider->parse($content))->toBe($parsed);
+})->with([
+    [
+        'content' => 'This is a #hashtag',
+        'parsed' => 'This is a <span class="text-blue-500">#hashtag</span>',
+    ],
+    [
+        'content' => '#hashtag at the beginning',
+        'parsed' => '<span class="text-blue-500">#hashtag</span> at the beginning',
+    ],
+    [
+        'content' => '#ab12z9_-',
+        'parsed' => '<span class="text-blue-500">#ab12z9_</span>-',
+    ],
+    [
+        'content' => '#hashtag.',
+        'parsed' => '<span class="text-blue-500">#hashtag</span>.',
+    ],
+    [
+        'content' => '#hashtag,',
+        'parsed' => '<span class="text-blue-500">#hashtag</span>,',
+    ],
+    [
+        'content' => '#hashtag!',
+        'parsed' => '<span class="text-blue-500">#hashtag</span>!',
+    ],
+    [
+        'content' => '#hashtag?',
+        'parsed' => '<span class="text-blue-500">#hashtag</span>?',
+    ],
+    [
+        'content' => '#hashtag/',
+        'parsed' => '<span class="text-blue-500">#hashtag</span>/',
+    ],
+    [
+        'content' => '##hashtag#',
+        'parsed' => '#<span class="text-blue-500">#hashtag</span>#',
+    ],
+    [
+        'content' => 'Existing <a href="/route#segment">link with #segment</a> and a #hashtag.',
+        'parsed' => 'Existing <a href="/route#segment">link with #segment</a> and a <span class="text-blue-500">#hashtag</span>.',
+    ],
+]);


### PR DESCRIPTION
Related to #371 

This PR simply adds hashtag (`#hashtag`) highlighting in posts.

A hashtag is identified by a `#` followed by a `[a-z0-9_]` case-insensitive.
Hashtags that are found in `<a>` elements will not be altered (this is the same logic as our mentions parsing). Thus, something like `<a href="/route#segment>link</a>"` will not be altered. 

This is step 1 in adding full hashtag support.