### PR TITLE
feat(hashtags) Fix html escapes

### DIFF
--- a/app/Services/ParsableContentProviders/HashtagProviderParsable.php
+++ b/app/Services/ParsableContentProviders/HashtagProviderParsable.php
@@ -14,7 +14,7 @@ final readonly class HashtagProviderParsable implements ParsableContentProvider
     public function parse(string $content): string
     {
         return (string) preg_replace_callback(
-            '/(<a\s+[^>]*>.*?<\/a>)|#([a-z0-9_]+)/i',
+            '/(<a\s+[^>]*>.*?<\/a>)|(?<!&)#([a-z0-9_]+)/i',
             fn (array $matches): string => $matches[1] !== ''
                 ? $matches[1]
                 : '<span class="text-blue-500">#'.$matches[2].'</span>',

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -275,4 +275,8 @@ test('hashtags', function (string $content, string $parsed) {
         'content' => 'Existing <a href="/route#segment">link with #segment</a> and a #hashtag.',
         'parsed' => 'Existing <a href="/route#segment">link with #segment</a> and a <span class="text-blue-500">#hashtag</span>.',
     ],
+    [
+        'content' => 'It&#039ll work with html escapes.',
+        'parsed' => 'It&#039ll work with html escapes.',
+    ],
 ]);


### PR DESCRIPTION
Added a negative lookbehind assertion for `&` preceding the `#`.

Added test to confirm this situation.

![image](https://github.com/user-attachments/assets/557b9251-e307-46f4-84d6-eddb1be8d00d)
