### PR TITLE
feat(hashtags) Do not alter #... found within code/pre blocks

### DIFF
--- a/app/Services/ParsableContentProviders/HashtagProviderParsable.php
+++ b/app/Services/ParsableContentProviders/HashtagProviderParsable.php
@@ -14,10 +14,10 @@ final readonly class HashtagProviderParsable implements ParsableContentProvider
     public function parse(string $content): string
     {
         return (string) preg_replace_callback(
-            '/(<a\s+[^>]*>.*?<\/a>)|(?<!&)#([a-z0-9_]+)/i',
+            '/(<(a|code|pre)\s+[^>]*>.*?<\/\2>)|(?<!&)#([a-z0-9_]+)/is',
             fn (array $matches): string => $matches[1] !== ''
                 ? $matches[1]
-                : '<span class="text-blue-500">#'.$matches[2].'</span>',
+                : '<span class="text-blue-500">#'.$matches[3].'</span>',
             $content
         );
     }

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -276,7 +276,19 @@ test('hashtags', function (string $content, string $parsed) {
         'parsed' => 'Existing <a href="/route#segment">link with #segment</a> and a <span class="text-blue-500">#hashtag</span>.',
     ],
     [
-        'content' => 'It&#039ll work with html escapes.',
-        'parsed' => 'It&#039ll work with html escapes.',
+        'content' => 'It&#039;ll work with html escapes.',
+        'parsed' => 'It&#039;ll work with html escapes.',
+    ],
+    [
+        'content' => 'It works with <pre style="position: relative;"><code class="p-4 rounded-lg hljs php text-xs group/code" style="background-color: #23262E">
+        multiline $codeBlocks = <span class="hljs-keyword">true</span>;
+        #comment
+        </code></pre>
+        #hashtag',
+        'parsed' => 'It works with <pre style="position: relative;"><code class="p-4 rounded-lg hljs php text-xs group/code" style="background-color: #23262E">
+        multiline $codeBlocks = <span class="hljs-keyword">true</span>;
+        #comment
+        </code></pre>
+        <span class="text-blue-500">#hashtag</span>',
     ],
 ]);


### PR DESCRIPTION
Was brought up that code blocks were experiencing problems with the new hashtag highlighting.

This PR adjusts the regex to exclude `#` symbols discovered within `pre` or `code` blocks (as well as `a` elements we had previously).

Before:
![image](https://github.com/user-attachments/assets/58849d33-cddb-46fa-a162-a717029629ed)

After:
![image](https://github.com/user-attachments/assets/63319f09-22f2-452e-850f-662cf7276f94)

Tests are good.
![image](https://github.com/user-attachments/assets/fc3f1905-2b7e-4e92-bf27-cea8bda70eab)
