### PR TITLE
Add paste support for images into textarea

### DIFF
--- a/resources/js/image-upload.js
+++ b/resources/js/image-upload.js
@@ -52,7 +52,7 @@ const imageUpload = () => ({
         // prevent default behavior to avoid pasting the title of the image
         event.preventDefault();
 
-        // build out the file list from the clipboard
+        // build out the file list from the clipboard, filtering only for images.
         const dataTransfer = new DataTransfer();
         for (const item of event.clipboardData.files) {
             if (!item.type.startsWith('image/')) {


### PR DESCRIPTION
**Summary**

Adds image upload on paste support. Supports issue #496 

Does client side checking for image mime types.

Happy for feedback, I'm no expert in Alpine, but it seemed reasonable to hijack the pre-existing client side image upload functionality and just hook it into a new event listener.