### PR TITLE
Fix: Escape special characters on remove image in markdown

### DIFF
--- a/resources/js/image-upload.js
+++ b/resources/js/image-upload.js
@@ -150,9 +150,16 @@ const imageUpload = () => ({
         this.uploading = false;
     },
 
+    escapeRegExp(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    },
+
     removeMarkdownImage(index) {
         let {path, originalName} = this.images[index];
-        let regex = new RegExp(`!\\[${originalName}\\]\\(${this.normalizePath(path)}\\)\\n?`, 'g');
+        let regex = new RegExp(
+            `!\\[${this.escapeRegExp(originalName)}\\]\\(${this.normalizePath(path)}\\)\\n?`,
+            'g'
+        );
         this.textarea.value = this.textarea.value.replace(regex, '');
         this.resizeTextarea();
     },


### PR DESCRIPTION
I found that if the image uploaded had certain characters, the current regex used would prevent it from being removed from the textbox when the image was deleted. This PR will resolve this isssue.

Before:

https://github.com/user-attachments/assets/c15fde1d-380f-4999-82a7-3c6c6a0197e7

After:

https://github.com/user-attachments/assets/53e8049a-b410-4cee-aadf-4fdd34f5d50e
