### PR TITLE
Changes the height of the parent questions divider

### DIFF
--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -34,7 +34,7 @@
 
             @foreach($parentQuestions as $parentQuestion)
                 <livewire:questions.show :questionId="$parentQuestion->id" :in-thread="false" />
-                <div class="relative -mt-11 -mb-14 h-14">
+                <div class="relative -mt-11 -mb-14 h-6">
                     <span class="absolute left-8 h-full w-1.5 rounded-full bg-slate-700" aria-hidden="true"></span>
                 </div>
             @endforeach


### PR DESCRIPTION
This changes the divider to the smaller version I show on this picture:

<img width="516" alt="image" src="https://github.com/user-attachments/assets/a8289863-de61-4bed-9a2c-06506997086d">
