### PR TITLE
Feat: bookmarks count

### DIFF
--- a/app/Livewire/Questions/Show.php
+++ b/app/Livewire/Questions/Show.php
@@ -253,8 +253,10 @@ final class Show extends Component
     public function render(): View
     {
         $question = Question::where('id', $this->questionId)
-            ->with(['to', 'from', 'likes'])
+            ->with(['to', 'from'])
             ->withExists(['bookmarks as is_bookmarked' => function (Builder $query): void {
+                $query->where('user_id', auth()->id());
+            }, 'likes as is_liked' => function (Builder $query): void {
                 $query->where('user_id', auth()->id());
             }])
             ->when(! $this->inThread || $this->commenting, function (Builder $query): void {

--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -200,7 +200,7 @@
                     <span>•</span>
 
                     @php
-                        $likeExists = $question->likes->contains('user_id', auth()->id());
+                        $likeExists = $question->is_liked;
                         $likesCount = $question->likes_count;
                     @endphp
 


### PR DESCRIPTION
This PR adds bookmark count beside the bookmark button similar to likes and comments count.
It also provides a better way to check if the post is bookmarked/liked. Basically now it checks if the current user's like exist or not at the place of getting all likes from the database for a question using the `withExists` method. Same for the bookmark button.