### PR TITLE
chore: refresh livewire without stubbed method

### DIFF
--- a/app/Livewire/Home/Feed.php
+++ b/app/Livewire/Home/Feed.php
@@ -12,6 +12,7 @@ use Illuminate\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
+#[On('question.created')]
 final class Feed extends Component
 {
     use HasLoadMore;
@@ -30,12 +31,6 @@ final class Feed extends Component
 
         $this->dispatch('question.ignored');
     }
-
-    /**
-     * Refresh the feed.
-     */
-    #[On('question.created')]
-    public function refresh(): void {}
 
     /**
      * Render the component.


### PR DESCRIPTION
Hey @nunomaduro,

first of all what a nice code base, congrats on that :+1: 

maybe this code style is intended or you may not know about this style to trigger a `$refresh` with an `listener`
as you can see in the livewire core there is a fallback to the magic `$refresh` if there is no name
![image](https://github.com/user-attachments/assets/732cdf49-fb34-424c-b870-dd873377b545)

Let me know if you like this or not.

Cheers Adrian