### PR TITLE
refactor the backup command to use SQLites backup method

### DIFF
--- a/app/Contracts/Services/DatabaseBackupProvider.php
+++ b/app/Contracts/Services/DatabaseBackupProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Services;
+
+interface DatabaseBackupProvider
+{
+    /**
+     * Parse the given "parsable" content.
+     */
+    public function performBackup(string $sourcePath, string $backupPath): void;
+}

--- a/app/Contracts/Services/DatabaseBackupProvider.php
+++ b/app/Contracts/Services/DatabaseBackupProvider.php
@@ -6,8 +6,5 @@ namespace App\Contracts\Services;
 
 interface DatabaseBackupProvider
 {
-    /**
-     * Parse the given "parsable" content.
-     */
     public function performBackup(string $sourcePath, string $backupPath): void;
 }

--- a/app/Services/DatabaseBackup.php
+++ b/app/Services/DatabaseBackup.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Contracts\Services\DatabaseBackupProvider;
-use Exception;
 use SQLite3;
-use Throwable;
 
 final class DatabaseBackup implements DatabaseBackupProvider
 {
@@ -21,8 +19,6 @@ final class DatabaseBackup implements DatabaseBackupProvider
             $backupDB = new SQLite3($backupPath, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE);
 
             $sourceDB->backup($backupDB);
-        } catch (Throwable $th) {
-            throw new Exception('Backup failed: '.$th->getMessage(), 0, $th);
         } finally {
             $this->closeDatabase($backupDB);
             $this->closeDatabase($sourceDB);

--- a/app/Services/DatabaseBackup.php
+++ b/app/Services/DatabaseBackup.php
@@ -21,7 +21,6 @@ final class DatabaseBackup implements DatabaseBackupProvider
 
             $sourceDB->backup($backupDB);
         } catch (Exception $e) {
-            // Log the error or handle it as per your application's error handling policy
             throw new Exception('Backup failed: '.$e->getMessage(), 0, $e);
         } finally {
             $this->closeDatabase($backupDB);

--- a/app/Services/DatabaseBackup.php
+++ b/app/Services/DatabaseBackup.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Contracts\Services\DatabaseBackupProvider;
 use Exception;
 use SQLite3;
+use Throwable;
 
 final class DatabaseBackup implements DatabaseBackupProvider
 {
@@ -20,8 +21,8 @@ final class DatabaseBackup implements DatabaseBackupProvider
             $backupDB = new SQLite3($backupPath, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE);
 
             $sourceDB->backup($backupDB);
-        } catch (Exception $e) {
-            throw new Exception('Backup failed: '.$e->getMessage(), 0, $e);
+        } catch (Throwable $th) {
+            throw new Exception('Backup failed: '.$th->getMessage(), 0, $th);
         } finally {
             $this->closeDatabase($backupDB);
             $this->closeDatabase($sourceDB);

--- a/app/Services/DatabaseBackup.php
+++ b/app/Services/DatabaseBackup.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\Services\DatabaseBackupProvider;
+use Exception;
+use SQLite3;
+
+final class DatabaseBackup implements DatabaseBackupProvider
+{
+    public function performBackup(string $sourcePath, string $backupPath): void
+    {
+        $sourceDB = null;
+        $backupDB = null;
+
+        try {
+            $sourceDB = new SQLite3($sourcePath, SQLITE3_OPEN_READONLY);
+            $backupDB = new SQLite3($backupPath, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE);
+
+            $sourceDB->backup($backupDB);
+        } catch (Exception $e) {
+            // Log the error or handle it as per your application's error handling policy
+            throw new Exception('Backup failed: '.$e->getMessage(), 0, $e);
+        } finally {
+            $this->closeDatabase($backupDB);
+            $this->closeDatabase($sourceDB);
+        }
+    }
+
+    private function closeDatabase(?SQLite3 $database): void
+    {
+        if ($database instanceof SQLite3) {
+            $database->close();
+        }
+    }
+}

--- a/tests/Console/PerformDatabaseBackupCommandTest.php
+++ b/tests/Console/PerformDatabaseBackupCommandTest.php
@@ -46,7 +46,6 @@ test('perform database backup', function () {
         ->with(database_path('backups/backup-1.sql'))
         ->andReturnTrue();
 
-    // Execute the artisan command
     $this->artisan(PerformDatabaseBackupCommand::class)
         ->assertExitCode(0);
 });

--- a/tests/Console/PerformDatabaseBackupCommandTest.php
+++ b/tests/Console/PerformDatabaseBackupCommandTest.php
@@ -3,12 +3,16 @@
 declare(strict_types=1);
 
 use App\Console\Commands\PerformDatabaseBackupCommand;
+use App\Contracts\Services\DatabaseBackupProvider;
 use Illuminate\Support\Facades\File;
 
 test('perform database backup', function () {
-    File::shouldReceive('copy')
-        ->once()
-        ->with(database_path('database.sqlite'), Mockery::type('string'));
+    $backupService = Mockery::mock(DatabaseBackupProvider::class);
+
+    $this->app->instance(DatabaseBackupProvider::class, $backupService);
+
+    $backupService->shouldReceive('performBackup')
+        ->once();
 
     File::shouldReceive('glob')
         ->once()
@@ -42,6 +46,7 @@ test('perform database backup', function () {
         ->with(database_path('backups/backup-1.sql'))
         ->andReturnTrue();
 
+    // Execute the artisan command
     $this->artisan(PerformDatabaseBackupCommand::class)
         ->assertExitCode(0);
 });

--- a/tests/Unit/Services/DatabaseBackupTest.php
+++ b/tests/Unit/Services/DatabaseBackupTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DatabaseBackup;
+
+test('backs up a sqlite database', function () {
+    // Create temporary database files
+    $sourceDBPath = tempnam(sys_get_temp_dir(), 'source_db_');
+    $backupDBPath = tempnam(sys_get_temp_dir(), 'backup_db_');
+
+    $sourceDB = new SQLite3($sourceDBPath);
+    $backupDB = new SQLite3($backupDBPath);
+
+    try {
+        // Check if backup DB is empty
+        $result = $backupDB->query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'");
+        $this->assertEmpty($result->fetchArray(), 'Backup database should not contain any user tables initially');
+
+        // Set up source database
+        $sourceDB->exec('CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)');
+        $sourceDB->exec("INSERT INTO test (name) VALUES ('data1'), ('data2'), ('data3')");
+
+        // Perform backup
+        $backupService = new DatabaseBackup();
+        $backupService->performBackup($sourceDBPath, $backupDBPath);
+
+        // Verify backup
+        $result = $backupDB->query('SELECT name FROM test ORDER BY id');
+        $expected = ['data1', 'data2', 'data3'];
+        $i = 0;
+        while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+            $this->assertEquals($expected[$i], $row['name'], "Row $i should match");
+            $i++;
+        }
+        $this->assertEquals(3, $i, 'Should have backed up 3 rows');
+    } finally {
+        if (isset($sourceDB)) {
+            $sourceDB->close();
+        }
+        if (isset($backupDB)) {
+            $backupDB->close();
+        }
+        if (file_exists($sourceDBPath)) {
+            unlink($sourceDBPath);
+        }
+        if (file_exists($backupDBPath)) {
+            unlink($backupDBPath);
+        }
+    }
+});


### PR DESCRIPTION
I will preface this by saying I'm definitely not a SQLite master but from what I understand just copying the file can have a risk of corruption especially when using something like WAL mode. I attempted to update your clone command to use the actual backup method from SQLite. If there are any code conventions I broke let me know.

I wasn't sure how Pinkary wants to handle exceptions so I am just throwing an exception if for some reason the backing up fails.