### PR TITLE
Refactor/change qr generator

### DIFF
--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -52,7 +52,7 @@ final readonly class QrCodeController
         $icon = new Imagick(public_path('img/ico.png'));
 
         $iconSize = 100;
-        $icon->resizeImage($iconSize, $iconSize, Imagick::FILTER_LANCZOS, 1);
+        $icon->resizeImage($iconSize, $iconSize, Imagick::FILTER_POINT, 1);
 
         // Calculate the position to place the icon
         $x = ($qrCodeImage->getImageWidth() - $iconSize) / 2;

--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\User;
-use Illuminate\Http\Request;
 use BaconQrCode\Common\ErrorCorrectionLevel;
 use BaconQrCode\Encoder\Encoder;
+use BaconQrCode\Renderer\Color\Rgb;
 use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
 use BaconQrCode\Renderer\ImageRenderer;
-use BaconQrCode\Renderer\RendererStyle\RendererStyle;
-use BaconQrCode\Writer;
-use BaconQrCode\Renderer\Color\Rgb;
 use BaconQrCode\Renderer\RendererStyle\EyeFill;
 use BaconQrCode\Renderer\RendererStyle\Fill;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use BaconQrCode\Writer;
+use Illuminate\Http\Request;
 use Imagick;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -59,7 +59,7 @@ final readonly class QrCodeController
         $y = ($qrCodeImage->getImageHeight() - $iconSize) / 2;
 
         // Overlay the icon onto the QR code
-        $qrCodeImage->compositeImage($icon, Imagick::COMPOSITE_OVER, (int)$x, (int)$y);
+        $qrCodeImage->compositeImage($icon, Imagick::COMPOSITE_OVER, (int) $x, (int) $y);
 
         $qrCode = $qrCodeImage->getImageBlob();
 
@@ -68,7 +68,7 @@ final readonly class QrCodeController
                 /** @var string $qrCode */
                 echo $qrCode;
             },
-            'pinkary_' . $user->username . '.png',
+            'pinkary_'.$user->username.'.png',
             ['Content-Type' => 'image/png']
         );
     }

--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -31,7 +31,7 @@ final readonly class QrCodeController
         $foregroundColor = new Rgb(236, 72, 153);
 
         // Generate the QR code
-        $base64QrCode = (new Writer(
+        $qrCodeBinary = (new Writer(
             renderer: new ImageRenderer(
                 rendererStyle: new RendererStyle(size: 512, margin: 0, fill: Fill::withForegroundColor($backgroundColor, $foregroundColor, EyeFill::inherit(), EyeFill::inherit(), EyeFill::inherit())),
                 imageBackEnd: new ImagickImageBackEnd()
@@ -46,7 +46,7 @@ final readonly class QrCodeController
 
         // Load the QR code image
         $qrCodeImage = new Imagick();
-        $qrCodeImage->readImageBlob($base64QrCode);
+        $qrCodeImage->readImageBlob($qrCodeBinary);
 
         // Load the icon
         $icon = new Imagick(public_path('img/ico.png'));

--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -6,8 +6,16 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use Illuminate\Http\Request;
-use SimpleSoftwareIO\QrCode\Facades\QrCode;
-use SimpleSoftwareIO\QrCode\Generator;
+use BaconQrCode\Common\ErrorCorrectionLevel;
+use BaconQrCode\Encoder\Encoder;
+use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use BaconQrCode\Writer;
+use BaconQrCode\Renderer\Color\Rgb;
+use BaconQrCode\Renderer\RendererStyle\EyeFill;
+use BaconQrCode\Renderer\RendererStyle\Fill;
+use Imagick;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final readonly class QrCodeController
@@ -19,26 +27,48 @@ final readonly class QrCodeController
     {
         $user = type($request->user())->as(User::class);
 
-        /** @var Generator $qrCodeGenerator */
-        $qrCodeGenerator = QrCode::getFacadeRoot();
+        $backgroundColor = new Rgb(3, 7, 18);
+        $foregroundColor = new Rgb(236, 72, 153);
 
-        $qrCode = $qrCodeGenerator
-            ->size(512)
-            ->format('png')
-            ->backgroundColor(3, 7, 18, 100)
-            ->color(236, 72, 153, 100)
-            ->merge('/public/img/ico.png')
-            ->errorCorrection('M')
-            ->generate(route('profile.show', [
+        // Generate the QR code
+        $base64QrCode = (new Writer(
+            renderer: new ImageRenderer(
+                rendererStyle: new RendererStyle(size: 512, margin: 0, fill: Fill::withForegroundColor($backgroundColor, $foregroundColor, EyeFill::inherit(), EyeFill::inherit(), EyeFill::inherit())),
+                imageBackEnd: new ImagickImageBackEnd()
+            )
+        ))->writeString(
+            content: route('profile.show', [
                 'username' => $user->username,
-            ]));
+            ]),
+            encoding: Encoder::DEFAULT_BYTE_MODE_ECODING,
+            ecLevel: ErrorCorrectionLevel::M()
+        );
+
+        // Load the QR code image
+        $qrCodeImage = new Imagick();
+        $qrCodeImage->readImageBlob($base64QrCode);
+
+        // Load the icon
+        $icon = new Imagick(public_path('img/ico.png'));
+
+        $iconSize = 100;
+        $icon->resizeImage($iconSize, $iconSize, Imagick::FILTER_LANCZOS, 1);
+
+        // Calculate the position to place the icon
+        $x = ($qrCodeImage->getImageWidth() - $iconSize) / 2;
+        $y = ($qrCodeImage->getImageHeight() - $iconSize) / 2;
+
+        // Overlay the icon onto the QR code
+        $qrCodeImage->compositeImage($icon, Imagick::COMPOSITE_OVER, (int)$x, (int)$y);
+
+        $qrCode = $qrCodeImage->getImageBlob();
 
         return response()->streamDownload(
             function () use ($qrCode): void {
                 /** @var string $qrCode */
                 echo $qrCode;
             },
-            'pinkary_'.$user->username.'.png',
+            'pinkary_' . $user->username . '.png',
             ['Content-Type' => 'image/png']
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "matomo/device-detector": "^6.3.2",
         "pinkary-project/type-guard": "^0.1.0",
         "scrivo/highlight.php": "^9.18.1.10",
-        "simplesoftwareio/simple-qrcode": "^4.2",
+        "bacon/bacon-qr-code": "^2.0",
         "spatie/laravel-mailcoach-mailer": "^1.3.0",
         "ext-imagick": "^3.7.0"
     },

--- a/tests/Http/QrCodeTest.php
+++ b/tests/Http/QrCodeTest.php
@@ -48,7 +48,7 @@ test('user can download qr code', function () {
     $icon = new Imagick(public_path('img/ico.png'));
 
     $iconSize = 100;
-    $icon->resizeImage($iconSize, $iconSize, Imagick::FILTER_LANCZOS, 1);
+    $icon->resizeImage($iconSize, $iconSize, Imagick::FILTER_POINT, 1);
 
     // Calculate the position to place the icon
     $x = ($qrCodeImage->getImageWidth() - $iconSize) / 2;

--- a/tests/Http/QrCodeTest.php
+++ b/tests/Http/QrCodeTest.php
@@ -3,6 +3,16 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use BaconQrCode\Common\ErrorCorrectionLevel;
+use BaconQrCode\Encoder\Encoder;
+use BaconQrCode\Renderer\Color\Rgb;
+use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use BaconQrCode\Renderer\RendererStyle\EyeFill;
+use BaconQrCode\Renderer\RendererStyle\Fill;
+use BaconQrCode\Writer;
+use Imagick;
 
 test('can QR Code be downloaded only by authenticated users', function () {
     $response = $this->get(route('qr-code.image'));
@@ -13,21 +23,48 @@ test('can QR Code be downloaded only by authenticated users', function () {
 test('user can download qr code', function () {
     $user = User::factory()->create();
 
-    $qrCode = QrCode::size(512)
-        ->format('png')
-        ->backgroundColor(3, 7, 18, 100)
-        ->color(236, 72, 153, 100)
-        ->merge('/public/img/ico.png')
-        ->errorCorrection('M')
-        ->generate(route('profile.show', [
-            'username' => $user->username,
-        ]));
+    // Generate the QR code using the same logic as in the controller
+    $backgroundColor = new Rgb(3, 7, 18);
+    $foregroundColor = new Rgb(236, 72, 153);
 
+    $base64QrCode = (new Writer(
+        renderer: new ImageRenderer(
+            rendererStyle: new RendererStyle(size: 512, margin: 0, fill: Fill::withForegroundColor($backgroundColor, $foregroundColor, EyeFill::inherit(), EyeFill::inherit(), EyeFill::inherit())),
+            imageBackEnd: new ImagickImageBackEnd()
+        )
+    ))->writeString(
+        content: route('profile.show', [
+            'username' => $user->username,
+        ]),
+        encoding: Encoder::DEFAULT_BYTE_MODE_ECODING,
+        ecLevel: ErrorCorrectionLevel::M()
+    );
+
+    // Load the QR code image
+    $qrCodeImage = new Imagick();
+    $qrCodeImage->readImageBlob($base64QrCode);
+
+    // Load the icon
+    $icon = new Imagick(public_path('img/ico.png'));
+
+    $iconSize = 100;
+    $icon->resizeImage($iconSize, $iconSize, Imagick::FILTER_LANCZOS, 1);
+
+    // Calculate the position to place the icon
+    $x = ($qrCodeImage->getImageWidth() - $iconSize) / 2;
+    $y = ($qrCodeImage->getImageHeight() - $iconSize) / 2;
+
+    // Overlay the icon onto the QR code
+    $qrCodeImage->compositeImage($icon, Imagick::COMPOSITE_OVER, (int)$x, (int)$y);
+
+    $qrCode = $qrCodeImage->getImageBlob();
+
+    // Simulate downloading the QR code
     $response = $this->actingAs($user)->get(route('qr-code.image'));
 
     $response
         ->assertOk()
-        ->assertStreamedContent($qrCode->toHtml())
         ->assertHeader('content-type', 'image/png')
-        ->assertDownload('pinkary_'.$user->username.'.png');
+        ->assertDownload('pinkary_' . $user->username . '.png')
+        ->assertStreamedContent($qrCode);
 });

--- a/tests/Http/QrCodeTest.php
+++ b/tests/Http/QrCodeTest.php
@@ -27,7 +27,7 @@ test('user can download qr code', function () {
     $backgroundColor = new Rgb(3, 7, 18);
     $foregroundColor = new Rgb(236, 72, 153);
 
-    $base64QrCode = (new Writer(
+    $qrCodeBinary = (new Writer(
         renderer: new ImageRenderer(
             rendererStyle: new RendererStyle(size: 512, margin: 0, fill: Fill::withForegroundColor($backgroundColor, $foregroundColor, EyeFill::inherit(), EyeFill::inherit(), EyeFill::inherit())),
             imageBackEnd: new ImagickImageBackEnd()
@@ -42,7 +42,7 @@ test('user can download qr code', function () {
 
     // Load the QR code image
     $qrCodeImage = new Imagick();
-    $qrCodeImage->readImageBlob($base64QrCode);
+    $qrCodeImage->readImageBlob($qrCodeBinary);
 
     // Load the icon
     $icon = new Imagick(public_path('img/ico.png'));

--- a/tests/Http/QrCodeTest.php
+++ b/tests/Http/QrCodeTest.php
@@ -8,9 +8,9 @@ use BaconQrCode\Encoder\Encoder;
 use BaconQrCode\Renderer\Color\Rgb;
 use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
 use BaconQrCode\Renderer\ImageRenderer;
-use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Renderer\RendererStyle\EyeFill;
 use BaconQrCode\Renderer\RendererStyle\Fill;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
 use Imagick;
 
@@ -55,7 +55,7 @@ test('user can download qr code', function () {
     $y = ($qrCodeImage->getImageHeight() - $iconSize) / 2;
 
     // Overlay the icon onto the QR code
-    $qrCodeImage->compositeImage($icon, Imagick::COMPOSITE_OVER, (int)$x, (int)$y);
+    $qrCodeImage->compositeImage($icon, Imagick::COMPOSITE_OVER, (int) $x, (int) $y);
 
     $qrCode = $qrCodeImage->getImageBlob();
 
@@ -65,6 +65,6 @@ test('user can download qr code', function () {
     $response
         ->assertOk()
         ->assertHeader('content-type', 'image/png')
-        ->assertDownload('pinkary_' . $user->username . '.png')
+        ->assertDownload('pinkary_'.$user->username.'.png')
         ->assertStreamedContent($qrCode);
 });


### PR DESCRIPTION
Swapped out the QR code generator to remove the need for SimpleSoftwareIO/simple-qrcode as it no longer appears to be maintained. 

Followed suit of Laravel/Fortify and used bacon/bacon-qr-code directly. 

I decided to use Imagick as this is a dependency already but I could change to make use of the GD Library if you prefer, these are only needed as we are adding the ico.png over the top of the QR code. 