### PR TITLE
Refactor/change qr code generator

### DIFF
--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Services\QrCode;
 use Illuminate\Http\Request;
-use SimpleSoftwareIO\QrCode\Facades\QrCode;
-use SimpleSoftwareIO\QrCode\Generator;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final readonly class QrCodeController
@@ -19,19 +18,11 @@ final readonly class QrCodeController
     {
         $user = type($request->user())->as(User::class);
 
-        /** @var Generator $qrCodeGenerator */
-        $qrCodeGenerator = QrCode::getFacadeRoot();
-
-        $qrCode = $qrCodeGenerator
-            ->size(512)
-            ->format('png')
-            ->backgroundColor(3, 7, 18, 100)
-            ->color(236, 72, 153, 100)
-            ->merge('/public/img/ico.png')
-            ->errorCorrection('M')
-            ->generate(route('profile.show', [
+        $qrCode = (new QrCode())->generate(
+            route('profile.show', [
                 'username' => $user->username,
-            ]));
+            ])
+        );
 
         return response()->streamDownload(
             function () use ($qrCode): void {

--- a/app/Services/QrCode.php
+++ b/app/Services/QrCode.php
@@ -37,8 +37,8 @@ final class QrCode
      */
     public function generate(string $content): HtmlString
     {
-        $qrCodeBinary = $this->createQrCodeData($content);
-        $qrCodeImage = $this->createQrCodeImage($qrCodeBinary);
+        $qrCodeData = $this->createQrCodeData($content);
+        $qrCodeImage = $this->createQrCodeImage($qrCodeData);
 
         $this->addIconToQrCode($qrCodeImage);
 

--- a/app/Services/QrCode.php
+++ b/app/Services/QrCode.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use BaconQrCode\Common\ErrorCorrectionLevel;
+use BaconQrCode\Renderer\Color\Rgb;
+use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Renderer\RendererStyle\EyeFill;
+use BaconQrCode\Renderer\RendererStyle\Fill;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use BaconQrCode\Writer;
+use Illuminate\Support\HtmlString;
+use Imagick;
+
+final class QrCode
+{
+    private readonly Rgb $backgroundColor;
+
+    private readonly Rgb $foregroundColor;
+
+    private readonly string $iconPath;
+
+    private int $iconSize = 100;
+
+    public function __construct()
+    {
+        $this->backgroundColor = new Rgb(3, 7, 18);
+        $this->foregroundColor = new Rgb(236, 72, 153);
+        $this->iconPath = public_path('img/ico.png');
+    }
+
+    /**
+     * Generate a QR code for the given content.
+     */
+    public function generate(string $content): HtmlString
+    {
+        $qrCodeBinary = $this->createQrCodeData($content);
+        $qrCodeImage = $this->createQrCodeImage($qrCodeBinary);
+
+        $this->addIconToQrCode($qrCodeImage);
+
+        return new HtmlString($qrCodeImage->getImageBlob());
+    }
+
+    private function createQrCodeData(string $content): string
+    {
+        return (new Writer(
+            renderer: new ImageRenderer(
+                rendererStyle: new RendererStyle(
+                    size: 512,
+                    margin: 0,
+                    fill: Fill::withForegroundColor($this->backgroundColor, $this->foregroundColor, EyeFill::inherit(), EyeFill::inherit(), EyeFill::inherit())
+                ),
+                imageBackEnd: new ImagickImageBackEnd()
+            )
+        ))->writeString(
+            content: $content,
+            ecLevel: ErrorCorrectionLevel::M()
+        );
+    }
+
+    private function createQrCodeImage(string $qrCodeBinary): Imagick
+    {
+        $qrCodeImage = new Imagick();
+        $qrCodeImage->readImageBlob($qrCodeBinary);
+
+        return $qrCodeImage;
+    }
+
+    private function addIconToQrCode(Imagick $qrCodeImage): void
+    {
+        $icon = new Imagick($this->iconPath);
+
+        $icon->resizeImage($this->iconSize, $this->iconSize, Imagick::FILTER_UNDEFINED, 1);
+
+        $x = ($qrCodeImage->getImageWidth() - $this->iconSize) / 2;
+        $y = ($qrCodeImage->getImageHeight() - $this->iconSize) / 2;
+
+        $qrCodeImage->compositeImage($icon, Imagick::COMPOSITE_OVER, (int) $x, (int) $y);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "matomo/device-detector": "^6.3.2",
         "pinkary-project/type-guard": "^0.1.0",
         "scrivo/highlight.php": "^9.18.1.10",
-        "simplesoftwareio/simple-qrcode": "^4.2",
+        "bacon/bacon-qr-code": "^2.0",
         "spatie/laravel-mailcoach-mailer": "^1.3.0",
         "ext-imagick": "^3.7.0"
     },

--- a/tests/Http/QrCodeTest.php
+++ b/tests/Http/QrCodeTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use App\Services\QrCode;
 
 test('can QR Code be downloaded only by authenticated users', function () {
     $response = $this->get(route('qr-code.image'));
@@ -13,15 +14,11 @@ test('can QR Code be downloaded only by authenticated users', function () {
 test('user can download qr code', function () {
     $user = User::factory()->create();
 
-    $qrCode = QrCode::size(512)
-        ->format('png')
-        ->backgroundColor(3, 7, 18, 100)
-        ->color(236, 72, 153, 100)
-        ->merge('/public/img/ico.png')
-        ->errorCorrection('M')
-        ->generate(route('profile.show', [
+    $qrCode = (new QrCode())->generate(
+        route('profile.show', [
             'username' => $user->username,
-        ]));
+        ])
+    );
 
     $response = $this->actingAs($user)->get(route('qr-code.image'));
 


### PR DESCRIPTION
Swapped out the QR code generator to remove the need for SimpleSoftwareIO/simple-qrcode as it no longer appears to be maintained. 

Followed suit of Laravel/Fortify and used bacon/bacon-qr-code directly.

I decided to use Imagick as this is a dependency already but I could change to make use of the GD Library if you prefer, these are only needed as we are adding the ico.png over the top of the QR code.

