### PR TITLE
fix: search icon cut off in home menu components

### DIFF
--- a/resources/views/home/users.blade.php
+++ b/resources/views/home/users.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <div class="flex flex-col items-center justify-center">
-        <div class="min-h-screen w-full max-w-md overflow-hidden shadow-md">
+        <div class="min-h-screen w-full max-w-md overflow-hidden rounded-2xl px-2 shadow-md sm:px-0">
             <x-home-menu></x-home-menu>
 
             <livewire:home.users :focus-input="true" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,9 @@ export default {
             screens: {
                 xsm: '467px',
             },
+            maxWidth: {
+               'md': '30rem',
+            },
         },
     },
 


### PR DESCRIPTION
I found this bug UI on Firefox, I have checked on chrome its fine
![Screenshot from 2024-08-29 13-52-27](https://github.com/user-attachments/assets/4e7d2de9-e813-4d1e-b9a7-f029a918e79f)

the problem is on max-w-md it too small for handle 4 icon menu, if I change into max-w-lg I think the width too wide, so I create custom  wide with size 30rem, and this the result
![Screenshot from 2024-08-29 13-53-06](https://github.com/user-attachments/assets/c4a9bac1-6e77-43d8-9a40-130030be6395)

and for users or search menu I just the same as the other menus