### PR TITLE
fix: seeding the database

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,7 +4,17 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
-final class DatabaseSeeder extends Seeder {}
+final class DatabaseSeeder extends Seeder
+{
+    /**
+     * Seed the application's database.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}


### PR DESCRIPTION
For whatever reason if anyone tries to seed the database using the **php artisan db:seed** command or passing the **--seed** flag he will hit `InvalidArgumentException Method [run] missing from Database\Seeders\DatabaseSeeder`. So I inject that method.

- Database Connection: MySQL