### PR TITLE
Refactor image upload section in question creation

### DIFF
--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -27,52 +27,46 @@
                     />
                 </div>
 
-                <div class="absolute top-0 right-0 mt-2 mr-2 group-hover/menu:inline-block hidden">
-                    <button
-                        title="Upload an image"
-                        x-ref="imageButton"
-                        :disabled="uploading || images.length >= uploadLimit"
-                        class="rounded-lg bg-slate-800 text-sm text-slate-400 p-1.5 hover:text-pink-500"
-                        :class="{'cursor-not-allowed text-pink-500': uploading || images.length >= uploadLimit}"
-                    >
-                        <x-heroicon-o-camera class="h-5 w-5"/>
-                    </button>
-                </div>
-            <div
-                class="absolute top-0 right-0 mt-2 mr-2 group-hover/menu:inline-block hidden">
-                <button title="Upload an image" x-ref="imageButton"
-                        :disabled="uploading || images.length >= uploadLimit"
-                        class="rounded-lg bg-slate-800 text-sm text-slate-400 p-1.5 hover:text-pink-500"
-                        :class="{'cursor-not-allowed text-pink-500': uploading || images.length >= uploadLimit}"
-                >
-                    <x-heroicon-o-camera class="h-5 w-5"/>
-                </button>
-            </div>
-            <input class="hidden" type="file" x-ref="imageInput" multiple accept="image/*" />
-            <input class="hidden" type="file" x-ref="imageUpload" multiple accept="image/*" wire:model="images" />
-
-            <div x-show="images.length > 0" class="relative mt-2 flex h-20 flex-wrap gap-2">
-                <template x-for="(image, index) in images" :key="index">
-                    <div class="relative h-20 w-20">
-                        <img :src="image.path" :alt="image.originalName"
-                             x-on:click="createMarkdownImage(index)"
-                             title="Reinsert the image"
-                             class="h-full w-full rounded-lg object-cover cursor-pointer"/>
-                        <button @click="removeImage($event, index)"
-                                class="absolute top-0.5 right-0.5 p-1 rounded-md bg-slate-800 bg-opacity-75 text-slate-400 hover:text-pink-500">
-                            <x-icons.close class="size-4"/>
+            <div class="flex">
+                <div class="w-1/2">
+                    <div
+                            class="relative top-0 right-0 mr-2 group-hover/menu:inline-block hidden">
+                        <button title="Upload an image" x-ref="imageButton"
+                                :disabled="uploading || images.length >= uploadLimit"
+                                class="rounded-lg bg-slate-800 text-sm text-slate-400 p-1.5 hover:text-pink-500"
+                                :class="{'cursor-not-allowed text-pink-500': uploading || images.length >= uploadLimit}"
+                        >
+                            <x-heroicon-o-camera class="h-5 w-5"/>
                         </button>
                     </div>
-                </template>
+                    <input class="hidden" type="file" x-ref="imageInput" multiple accept="image/*" />
+                    <input class="hidden" type="file" x-ref="imageUpload" multiple accept="image/*" wire:model="images" />
+
+                    <div x-show="images.length > 0" class="relative mt-2 flex h-20 flex-wrap gap-2">
+                        <template x-for="(image, index) in images" :key="index">
+                            <div class="relative h-20 w-20">
+                                <img :src="image.path" :alt="image.originalName"
+                                     x-on:click="createMarkdownImage(index)"
+                                     title="Reinsert the image"
+                                     class="h-full w-full rounded-lg object-cover cursor-pointer"/>
+                                <button @click="removeImage($event, index)"
+                                        class="absolute top-0.5 right-0.5 p-1 rounded-md bg-slate-800 bg-opacity-75 text-slate-400 hover:text-pink-500">
+                                    <x-icons.close class="size-4"/>
+                                </button>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+                <div class="w-1/2">
+                    <p class="text-right text-xs text-slate-400"><span x-text="$wire.content.length"></span> / {{ $this->maxContentLength}}</p>
+
+                    <ul>
+                        <template x-for="(error, index) in errors" :key="index">
+                            <li class="py-2 text-sm text-red-600 w-full"><span x-text="error"></span></li>
+                        </template>
+                    </ul>
+                </div>
             </div>
-
-            <p class="text-right text-xs text-slate-400"><span x-text="$wire.content.length"></span> / {{ $this->maxContentLength}}</p>
-
-            <ul>
-                <template x-for="(error, index) in errors" :key="index">
-                    <li class="py-2 text-sm text-red-600 w-full"><span x-text="error"></span></li>
-                </template>
-            </ul>
 
         </div>
         <div class="mt-4 flex items-center justify-between gap-4">

--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -1,6 +1,11 @@
 <div
     class="mb-12 pt-4"
     id="questions-create"
+    x-data="{ ...imageUpload(), showCameraIcon: false }"
+    x-init='() => {
+                uploadLimit = {{ $this->uploadLimit }};
+                maxFileSize = {{ $this->maxFileSize }};
+            }'
 >
     <form
         wire:submit="store"
@@ -8,12 +13,7 @@
         wire:keydown.ctrl.enter="store"
     >
         <div
-            x-data="imageUpload"
-            x-init='() => {
-                uploadLimit = {{ $this->uploadLimit }};
-                maxFileSize = {{ $this->maxFileSize }};
-            }'
-            class="relative group/menu">
+            class="relative group/menu" @mouseenter="showCameraIcon = true" @click.outside="showCameraIcon = false">
                 <div x-data="{ content: $persist($wire.entangle('content')).as('{{ $this->draftKey }}') }">
                     <x-textarea
                         x-model="content"
@@ -27,47 +27,13 @@
                     />
                 </div>
 
-            <div class="flex">
-                <div class="w-1/2">
-                    <div
-                            class="relative top-0 right-0 mr-2 group-hover/menu:inline-block hidden">
-                        <button title="Upload an image" x-ref="imageButton"
-                                :disabled="uploading || images.length >= uploadLimit"
-                                class="rounded-lg bg-slate-800 text-sm text-slate-400 p-1.5 hover:text-pink-500"
-                                :class="{'cursor-not-allowed text-pink-500': uploading || images.length >= uploadLimit}"
-                        >
-                            <x-heroicon-o-camera class="h-5 w-5"/>
-                        </button>
-                    </div>
-                    <input class="hidden" type="file" x-ref="imageInput" multiple accept="image/*" />
-                    <input class="hidden" type="file" x-ref="imageUpload" multiple accept="image/*" wire:model="images" />
+                <p class="text-right text-xs text-slate-400"><span x-text="$wire.content.length"></span> / {{ $this->maxContentLength}}</p>
 
-                    <div x-show="images.length > 0" class="relative mt-2 flex h-20 flex-wrap gap-2">
-                        <template x-for="(image, index) in images" :key="index">
-                            <div class="relative h-20 w-20">
-                                <img :src="image.path" :alt="image.originalName"
-                                     x-on:click="createMarkdownImage(index)"
-                                     title="Reinsert the image"
-                                     class="h-full w-full rounded-lg object-cover cursor-pointer"/>
-                                <button @click="removeImage($event, index)"
-                                        class="absolute top-0.5 right-0.5 p-1 rounded-md bg-slate-800 bg-opacity-75 text-slate-400 hover:text-pink-500">
-                                    <x-icons.close class="size-4"/>
-                                </button>
-                            </div>
-                        </template>
-                    </div>
-                </div>
-                <div class="w-1/2">
-                    <p class="text-right text-xs text-slate-400"><span x-text="$wire.content.length"></span> / {{ $this->maxContentLength}}</p>
-
-                    <ul>
-                        <template x-for="(error, index) in errors" :key="index">
-                            <li class="py-2 text-sm text-red-600 w-full"><span x-text="error"></span></li>
-                        </template>
-                    </ul>
-                </div>
-            </div>
-
+                <ul>
+                    <template x-for="(error, index) in errors" :key="index">
+                        <li class="py-2 text-sm text-red-600 w-full"><span x-text="error"></span></li>
+                    </template>
+                </ul>
         </div>
         <div class="mt-4 flex items-center justify-between gap-4">
             <div class="flex items-center gap-4">
@@ -92,6 +58,35 @@
                     >
                 </div>
             @endif
+            <div class="w-full justify-items-start">
+                <div
+                        class="relative top-0 right-0 mr-2 inline-block" x-show="showCameraIcon">
+                    <button title="Upload an image" x-ref="imageButton"
+                            :disabled="uploading || images.length >= uploadLimit"
+                            class="rounded-lg bg-slate-800 text-sm text-slate-400 p-1.5 hover:text-pink-500"
+                            :class="{'cursor-not-allowed text-pink-500': uploading || images.length >= uploadLimit}"
+                    >
+                        <x-heroicon-o-camera class="h-5 w-5"/>
+                    </button>
+                </div>
+                <input class="hidden" type="file" x-ref="imageInput" multiple accept="image/*" />
+                <input class="hidden" type="file" x-ref="imageUpload" multiple accept="image/*" wire:model="images" />
+
+                <div x-show="images.length > 0" class="relative mt-2 flex h-20 flex-wrap gap-2">
+                    <template x-for="(image, index) in images" :key="index">
+                        <div class="relative h-20 w-20">
+                            <img :src="image.path" :alt="image.originalName"
+                                 x-on:click="createMarkdownImage(index)"
+                                 title="Reinsert the image"
+                                 class="h-full w-full rounded-lg object-cover cursor-pointer"/>
+                            <button @click="removeImage($event, index)"
+                                    class="absolute top-0.5 right-0.5 p-1 rounded-md bg-slate-800 bg-opacity-75 text-slate-400 hover:text-pink-500">
+                                <x-icons.close class="size-4"/>
+                            </button>
+                        </div>
+                    </template>
+                </div>
+            </div>
         </div>
     </form>
 </div>


### PR DESCRIPTION
Consolidate and organize HTML structure for the image upload components. This refactor simplifies the layout by utilizing flex containers and removes redundant elements. It also ensures better alignment and error handling within the image upload section.

This commit also prevents the camera icon overlays the text.

<img width="519" alt="Captura de Tela 2024-08-30 às 22 48 30" src="https://github.com/user-attachments/assets/8097a32b-1bf1-4413-9550-f7695823f8e2">
