### PR TITLE
chore: intersect margin value to 50%

### DIFF
--- a/resources/views/components/load-more-button.blade.php
+++ b/resources/views/components/load-more-button.blade.php
@@ -1,5 +1,5 @@
 @if ($perPage < 100 && $paginator->hasMorePages())
-    <div x-intersect.margin.200px="$wire.loadMore()" class="text-center">
+    <div x-intersect.margin.50%="$wire.loadMore()" class="text-center">
         <div class="text-center text-slate-400" wire:loading wire:target="loadMore">
             <x-heroicon-o-arrow-path class="w-5 h-5 animate-spin" />
         </div>


### PR DESCRIPTION
It seems 50% works well on mobile and desktop and does not have fast scrolling or footer issues either.