### PR TITLE
Fix: is_uploaded_avatar column pos in users table

### DIFF
--- a/database/migrations/2024_08_31_111636_correct_is_uploaded_avatar_column_position_in_users_table.php
+++ b/database/migrations/2024_08_31_111636_correct_is_uploaded_avatar_column_position_in_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        $usersWithUploadedAvatarIds = User::query()->select('id')
+                                        ->where('is_uploaded_avatar', true)
+                                        ->pluck('id');
+
+        Schema::table('users', function (Blueprint $table) {
+
+            $table->dropColumn('is_uploaded_avatar');
+
+            $table->boolean('is_uploaded_avatar')->default(false)->after('avatar_updated_at');
+        });
+
+        User::query()->whereIn('id', $usersWithUploadedAvatarIds)
+            ->update(['is_uploaded_avatar' => true]);
+    }
+};


### PR DESCRIPTION
While reading the code of this nice project, I've noticed this **avatar_updated_at()** function inside **add_is_uploaded_avatar_column_to_users_table** migration file.

I think it's meant to be **after('avatar_updated_at')**, so i tried to fix this issue while preserving old values for this column.