### PR TITLE
remove unnecessary username check query as it's handled by unique rule

### DIFF
--- a/app/Rules/Username.php
+++ b/app/Rules/Username.php
@@ -656,15 +656,5 @@ final readonly class Username implements ValidationRule
 
             return;
         }
-
-        $query = User::whereRaw('lower(username) = ?', [mb_strtolower($value)]);
-
-        if ($this->user instanceof User) {
-            $query->where('id', '!=', $this->user->id);
-        }
-
-        if ($query->exists()) {
-            $fail('The :attribute has already been taken.');
-        }
     }
 }


### PR DESCRIPTION
As the default unique rule is used there is no need for the extra query check at the Username Custom Rule. 