### PR TITLE
Fix: Remove double ignore call in arch tests

### DIFF
--- a/tests/Arch/FactoriesTest.php
+++ b/tests/Arch/FactoriesTest.php
@@ -8,7 +8,6 @@ arch('factories')
     ->ignoring('Database\Factories\Concerns')
     ->toUse('Database\Factories\Concerns\RefreshOnCreate')
     ->toHaveMethod('definition')
-    ->ignoring('Database\Factories\Concerns')
     ->toOnlyBeUsedIn([
         'App\Models',
     ]);


### PR DESCRIPTION
This PR refactors the architectural tests to remove the redundant double `ignoring` call. The change simplifies the test chain, ensuring consistency and avoiding deprecated warnings in future versions of Pest.

- Removed the second `ignoring` method call from the test chain.
- Verified that the test runs correctly without triggering deprecation warnings.
