### PR TITLE
chore: followup - refresh livewire without stubbed method

### DIFF
--- a/app/Livewire/Bookmarks/Index.php
+++ b/app/Livewire/Bookmarks/Index.php
@@ -11,15 +11,10 @@ use Illuminate\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
+#[On('question.unbookmarked')]
 final class Index extends Component
 {
     use HasLoadMore;
-
-    /**
-     * Refresh the component.
-     */
-    #[On('question.unbookmarked')]
-    public function refresh(): void {}
 
     /**
      * Render the component.

--- a/app/Livewire/Links/Index.php
+++ b/app/Livewire/Links/Index.php
@@ -18,6 +18,9 @@ use Livewire\Attributes\Renderless;
 use Livewire\Component;
 use Symfony\Component\HttpFoundation\IpUtils;
 
+#[On('link.created')]
+#[On('link.updated')]
+#[On('link-settings.updated')]
 final class Index extends Component
 {
     /**
@@ -152,17 +155,6 @@ final class Index extends Component
         $user->following()->detach($targetId);
 
         $this->dispatch('user.unfollowed');
-    }
-
-    /**
-     * Refresh the component.
-     */
-    #[On('link.created')]
-    #[On('link.updated')]
-    #[On('link-settings.updated')]
-    public function refresh(): void
-    {
-        //
     }
 
     /**

--- a/app/Livewire/Navigation/NotificationsCount/Show.php
+++ b/app/Livewire/Navigation/NotificationsCount/Show.php
@@ -10,20 +10,12 @@ use Illuminate\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
+#[On('question.created')]
+#[On('question.updated')]
+#[On('question.reported')]
+#[On('question.ignored')]
 final class Show extends Component
 {
-    /**
-     * Refresh the component.
-     */
-    #[On('question.created')]
-    #[On('question.updated')]
-    #[On('question.reported')]
-    #[On('question.ignored')]
-    public function refresh(): void
-    {
-        //
-    }
-
     /**
      * Render the component.
      */

--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -25,6 +25,8 @@ use Livewire\WithFileUploads;
  * @property-read bool $isSharingUpdate
  * @property-read int $maxContentLength
  */
+#[On('link-settings.updated')]
+#[On('link-question.created')]
 final class Create extends Component
 {
     use WithFileUploads;
@@ -178,18 +180,6 @@ final class Create extends Component
         return filled($this->parentId)
             ? "reply_{$this->parentId}"
             : 'post_new';
-    }
-
-    /**
-     * Refresh the component.
-     */
-    #[On([
-        'link-settings.updated',
-        'question.created',
-    ])]
-    public function refresh(): void
-    {
-        //
     }
 
     /**

--- a/app/Livewire/Questions/Index.php
+++ b/app/Livewire/Questions/Index.php
@@ -16,6 +16,9 @@ use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
+#[On('question.created')]
+#[On('question.updated')]
+#[On('question.reported')]
 final class Index extends Component
 {
     use HasLoadMore;
@@ -57,14 +60,6 @@ final class Index extends Component
             'questions' => $questions,
         ]);
     }
-
-    /**
-     * Refresh the component.
-     */
-    #[On('question.created')]
-    #[On('question.updated')]
-    #[On('question.reported')]
-    public function refresh(): void {}
 
     /**
      * Ignore the given question.

--- a/app/Livewire/Questions/Show.php
+++ b/app/Livewire/Questions/Show.php
@@ -13,6 +13,8 @@ use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 
+#[On('question.updated')]
+#[On('question.created')]
 final class Show extends Component
 {
     /**
@@ -50,16 +52,6 @@ final class Show extends Component
      */
     #[Url]
     public ?string $previousQuestionId = null;
-
-    /**
-     * Refresh the component.
-     */
-    #[On('question.updated')]
-    #[On('question.created')]
-    public function refresh(): void
-    {
-        //
-    }
 
     /**
      * Get the listeners for the component.


### PR DESCRIPTION
Hey this is the followup PR from #518

I applied the change in all Livewire components and moved the `listeners` to the class to trigger a `$refresh`