### PR TITLE
Fixed formatting issue in Privacy Policy: removed space before @ in t…

### DIFF
--- a/resources/views/privacy.blade.php
+++ b/resources/views/privacy.blade.php
@@ -17,8 +17,7 @@
                 <p>
                     Welcome to Pinkary ("we," "us," "our"). We are committed to protecting your personal information and your right to privacy. If you
                     have any questions or concerns about this privacy notice, or our practices with regards to your personal information, please
-                    contact us at team
-                    @pinkary.com.
+                    contact us at team@pinkary.com.
                 </p>
 
                 <h2>1. Information We Collect</h2>


### PR DESCRIPTION
Fixed formatting issue in Privacy Policy: removed space before "@" in the contact email.


![Screenshot 2024-09-05 at 2 37 59 PM](https://github.com/user-attachments/assets/e16c5ca4-8825-442c-8a13-8f4ecb97fe57)


