### PR TITLE
feat(hashtags): add SyncMissingQuestionHashtags command

### DIFF
--- a/app/Console/Commands/SyncMissingQuestionHashtags.php
+++ b/app/Console/Commands/SyncMissingQuestionHashtags.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\EventActions\UpdateQuestionHashtags;
+use App\Models\Question;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+
+final class SyncMissingQuestionHashtags extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:sync-missing-hashtags {runtime=28 : The maximum execution time of the command}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync missing question hashtags';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $runtime = (int) $this->argument('runtime');
+        $runUntil = now()->addSeconds($runtime);
+        $halted = false;
+
+        $questions = Question::query()
+            ->whereDoesntHave('hashtags')
+            ->where(fn (Builder $where): Builder => $where
+                ->where('content', 'like', '%#%')
+                ->orWhere('answer', 'like', '%#%')
+            )
+            ->lazyByIdDesc();
+
+        $bar = $this->output->createProgressBar(count($questions));
+
+        $bar->start();
+
+        foreach ($questions as $question) {
+            if (now()->isAfter($runUntil)) {
+                $halted = true;
+                break;
+            }
+
+            (new UpdateQuestionHashtags($question))->handle();
+
+            $bar->advance();
+        }
+
+        if ($halted) {
+            $this->newLine();
+            $this->info('Halting process to limit runtime.');
+
+            return;
+        }
+
+        $bar->finish();
+    }
+}

--- a/tests/Console/SyncMissingQuestionHashtagsTest.php
+++ b/tests/Console/SyncMissingQuestionHashtagsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+it('syncs hashtag relations for questions that are missing hashtags', function () {
+    /** @var Tests\TestCase $this */
+    $withHashtags = App\Models\Question::factory(10)->create(['answer' => 'has a #hashtag']);
+    $withoutHashtags = App\Models\Question::factory(10)->create(['answer' => 'no hashtags here']);
+
+    Illuminate\Support\Facades\DB::table('hashtag_question')->truncate();
+
+    $this->artisan('app:sync-missing-hashtags')->assertSuccessful();
+
+    $withHashtags->load('hashtags');
+    $withoutHashtags->load('hashtags');
+
+    expect($withHashtags->every(
+        fn (App\Models\Question $question): bool => $question->hashtags->pluck('name')->all() === ['hashtag'])
+    )
+        ->toBeTrue();
+    expect($withoutHashtags->every(
+        fn (App\Models\Question $question): bool => $question->hashtags->isEmpty())
+    )
+        ->toBeTrue();
+});


### PR DESCRIPTION
Adds a (intended-to-be-temporary) console command to handle historic questions with hashtags.

`php artisan app:sync-missing-hashtags {runtime=28}`

It simply loops through existing questions that do not have any related hashtags and creates+attaches hashtags as necessary.

I'm not sure how long this will take to execute, so I made the command stop after a configurable runtime. It is safe to run multiple times back to back if needed.

This shouldn't be needed after fully syncing historic questions, so the command and test can be reverted upon completion.