### PR TITLE
Feat(hashtags): Make hashtags in posts a link to hashtag-feed

### DIFF
--- a/app/EventActions/UpdateQuestionHashtags.php
+++ b/app/EventActions/UpdateQuestionHashtags.php
@@ -52,7 +52,7 @@ final readonly class UpdateQuestionHashtags
             $matches,
         );
 
-        return collect($matches[1] ?? [])
+        return collect($matches[1] ?? []) // @phpstan-ignore-line
             ->filter()
             ->unique()
             ->values()

--- a/app/EventActions/UpdateQuestionHashtags.php
+++ b/app/EventActions/UpdateQuestionHashtags.php
@@ -44,16 +44,18 @@ final readonly class UpdateQuestionHashtags
     {
         $matches = [];
 
+        // When searching here, the hashtags will already be rendered as
+        // an <a> element, so we can specifically search for that.
         preg_match_all(
-            '/(<(a|code|pre)\s+[^>]*>.*?<\/\2>)|(?<!&)#([a-z0-9]+)/is',
+            '~<a\s+[^>]*href="/hashtag/([a-z0-9]+)"[^>]*>#\1</a>~i',
             "{$this->question->answer} {$this->question->content}",
             $matches,
         );
 
-        return collect($matches[3] ?? [])
+        return collect($matches[1] ?? [])
             ->filter()
             ->unique()
             ->values()
-            ->map(fn (string $hashtag): string => Str::limit($hashtag, 50, ''));
+            ->map(fn (string $hashtag): string => Str::limit($hashtag, 200, ''));
     }
 }

--- a/app/Http/Controllers/HashtagController.php
+++ b/app/Http/Controllers/HashtagController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\View\View;
+
+final readonly class HashtagController
+{
+    /**
+     * Display posts for the hashtag.
+     */
+    public function __invoke(string $hashtag): View
+    {
+        return view('hashtag.show', [
+            'hashtag' => $hashtag,
+        ]);
+    }
+}

--- a/app/Livewire/Home/Feed.php
+++ b/app/Livewire/Home/Feed.php
@@ -17,6 +17,11 @@ final class Feed extends Component
     use HasLoadMore;
 
     /**
+     * The hashtag name that the queried questions should relate to.
+     */
+    public ?string $hashtag = null;
+
+    /**
      * Ignore the given question.
      */
     #[On('question.ignore')]
@@ -42,7 +47,7 @@ final class Feed extends Component
      */
     public function render(): View
     {
-        $questions = (new RecentQuestionsFeed())->builder()->simplePaginate($this->perPage);
+        $questions = (new RecentQuestionsFeed($this->hashtag))->builder()->simplePaginate($this->perPage);
 
         IncrementViews::dispatchUsingSession($questions->getCollection());
 

--- a/app/Queries/Feeds/RecentQuestionsFeed.php
+++ b/app/Queries/Feeds/RecentQuestionsFeed.php
@@ -10,6 +10,13 @@ use Illuminate\Database\Eloquent\Builder;
 final readonly class RecentQuestionsFeed
 {
     /**
+     * Create a new instance of the RecentQuestionsFeed.
+     */
+    public function __construct(
+        private ?string $hashtag = null,
+    ) {}
+
+    /**
      * Get the query builder for the feed.
      *
      * @return Builder<Question>
@@ -20,6 +27,14 @@ final readonly class RecentQuestionsFeed
             ->where('answer', '!=', null)
             ->where('is_ignored', false)
             ->where('is_reported', false)
+            ->when($this->hashtag, fn (Builder $query) => $query
+                ->whereHas('hashtags', fn ($query) => $query
+                    // using 'like' for this query (with no wildcards) will
+                    // result in a case-insensitive lookup from sqlite,
+                    // which is what we want.
+                    ->where('name', 'like', $this->hashtag)
+                )
+            )
             ->orderByDesc('updated_at');
     }
 }

--- a/app/Services/ParsableContentProviders/HashtagProviderParsable.php
+++ b/app/Services/ParsableContentProviders/HashtagProviderParsable.php
@@ -16,12 +16,19 @@ final readonly class HashtagProviderParsable implements ParsableContentProvider
     {
         return (string) preg_replace_callback(
             '/(<(a|code|pre)\s+[^>]*>.*?<\/\2>)|(?<!&)#([a-z0-9]+)/is',
-            fn (array $matches): string => $matches[1] !== ''
-                ? $matches[1]
-                : sprintf(
-                    '<span class="text-blue-500">#%s</span>',
-                    Str::limit($matches[3], 200, '')
-                ),
+            function (array $matches): string {
+                if ($matches[1] !== '') {
+                    return $matches[1];
+                }
+
+                $sanitizedHashtag = Str::limit($matches[3], 200, '');
+
+                return sprintf(
+                    '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="%s">#%s</a>',
+                    "/hashtag/{$sanitizedHashtag}",
+                    $sanitizedHashtag
+                );
+            },
             $content
         );
     }

--- a/resources/views/hashtag/show.blade.php
+++ b/resources/views/hashtag/show.blade.php
@@ -1,0 +1,11 @@
+<x-app-layout>
+    <x-slot name="title">Recent posts with <span class="text-blue-500">#{{ $hashtag }}</span></x-slot>
+
+    <div class="flex flex-col items-center justify-center">
+        <div class="w-full max-w-md overflow-hidden rounded-lg px-2 shadow-md sm:px-0">
+            <x-home-menu></x-home-menu>
+
+            <livewire:home.feed :hashtag="$hashtag" />
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\BookmarksController;
 use App\Http\Controllers\ChangelogController;
+use App\Http\Controllers\HashtagController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\QrCodeController;
 use App\Http\Controllers\QuestionController;
@@ -21,6 +22,8 @@ Route::view('/', 'home/feed')->name('home.feed');
 Route::view('/for-you', 'home/questions-for-you')->name('home.for_you');
 Route::view('/trending', 'home/trending-questions')->name('home.trending');
 Route::view('/users', 'home/users')->name('home.users');
+
+Route::get('/hashtag/{hashtag}', HashtagController::class)->name('hashtag.show');
 
 Route::view('/terms', 'terms')->name('terms');
 Route::view('/privacy', 'privacy')->name('privacy');

--- a/tests/Http/Hashtag/ShowTest.php
+++ b/tests/Http/Hashtag/ShowTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+it('shows recent posts with the route-binded hashtag', function () {
+    $user = User::factory()->create();
+    App\Models\Question::factory()->create(['answer' => '#hashtag1']);
+    App\Models\Question::factory()->create(['answer' => 'not a hashtag in sight']);
+
+    $response = $this->actingAs($user)->get('/hashtag/hashtag1');
+
+    $response
+        ->assertOk()
+        ->assertSee('#hashtag1')
+        ->assertDontSee('not a hashtag in sight');
+});
+
+it('guests are allowed to view', function () {
+    App\Models\Question::factory()->create(['answer' => '#hashtag1']);
+
+    $response = $this->get('/hashtag/hashtag1');
+
+    $response
+        ->assertOk()
+        ->assertSee('#hashtag1');
+});

--- a/tests/Unit/Feeds/RecentQuestionsTest.php
+++ b/tests/Unit/Feeds/RecentQuestionsTest.php
@@ -63,3 +63,14 @@ it('builder returns Eloquent\Builder instance', function () {
 
     expect($builder)->toBeInstanceOf(Builder::class);
 });
+
+it('can filter questions to those related to a hashtag name', function () {
+    $questionWithHashtag = Question::factory()->create(['answer' => 'question 1 with a #hashtag']);
+
+    Question::factory()->create(['answer' => 'question 2 without hashtags']);
+
+    $builder = (new RecentQuestionsFeed('hashtag'))->builder();
+
+    expect($builder->get()->pluck('id')->all())
+        ->toBe([$questionWithHashtag->id]);
+});

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -295,43 +295,43 @@ test('hashtags', function (string $content, string $parsed) {
 })->with([
     [
         'content' => 'This is a #hashtag',
-        'parsed' => 'This is a <span class="text-blue-500">#hashtag</span>',
+        'parsed' => 'This is a <a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>',
     ],
     [
         'content' => '#hashtag at the beginning',
-        'parsed' => '<span class="text-blue-500">#hashtag</span> at the beginning',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a> at the beginning',
     ],
     [
         'content' => '#ab12z9_-',
-        'parsed' => '<span class="text-blue-500">#ab12z9</span>_-',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/ab12z9">#ab12z9</a>_-',
     ],
     [
         'content' => '#hashtag.',
-        'parsed' => '<span class="text-blue-500">#hashtag</span>.',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>.',
     ],
     [
         'content' => '#hashtag,',
-        'parsed' => '<span class="text-blue-500">#hashtag</span>,',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>,',
     ],
     [
         'content' => '#hashtag!',
-        'parsed' => '<span class="text-blue-500">#hashtag</span>!',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>!',
     ],
     [
         'content' => '#hashtag?',
-        'parsed' => '<span class="text-blue-500">#hashtag</span>?',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>?',
     ],
     [
         'content' => '#hashtag/',
-        'parsed' => '<span class="text-blue-500">#hashtag</span>/',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>/',
     ],
     [
         'content' => '##hashtag#',
-        'parsed' => '#<span class="text-blue-500">#hashtag</span>#',
+        'parsed' => '#<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>#',
     ],
     [
         'content' => 'Existing <a href="/route#segment">link with #segment</a> and a #hashtag.',
-        'parsed' => 'Existing <a href="/route#segment">link with #segment</a> and a <span class="text-blue-500">#hashtag</span>.',
+        'parsed' => 'Existing <a href="/route#segment">link with #segment</a> and a <a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>.',
     ],
     [
         'content' => 'It&#039;ll work with html escapes.',
@@ -347,10 +347,10 @@ test('hashtags', function (string $content, string $parsed) {
         multiline $codeBlocks = <span class="hljs-keyword">true</span>;
         #comment
         </code></pre>
-        <span class="text-blue-500">#hashtag</span>',
+        <a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/hashtag">#hashtag</a>',
     ],
     [
         'content' => '#extremelylonghashtagswillbeallowedaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        'parsed' => '<span class="text-blue-500">#extremelylonghashtagswillbeallowedaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</span>',
+        'parsed' => '<a class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" href="/hashtag/extremelylonghashtagswillbeallowedaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">#extremelylonghashtagswillbeallowedaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</a>',
     ],
 ]);


### PR DESCRIPTION
https://github.com/user-attachments/assets/1d9a0eec-4fc5-4a77-aa54-27fa85e28f0d

A pretty simple PR: make hashtags in posts a clickable link; clicking the link will take you to a feed of "recent posts with #___". This feed will show posts containing **any version (case-insensitive) of the hashtag string**, as shown in the video above (clicking `#LetsGo` also showed a post containing `#letsgo`).

Achieving this required an update to our hashtag parsing and relations updater, so the changed-files count is larger than the actual complexity of the feature.

Probably makes sense to deploy PR #564 and run that command before (or at the same time as) deploying this PR.

Up next will be the autocompletion stuff and then I think hashtags will be all done!