### PR TITLE
fix: Update upload icon from camera to image icon for clarity

### DIFF
--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -68,7 +68,7 @@
                     class="rounded-lg bg-slate-800 text-sm text-slate-400 p-1.5 hover:text-pink-500"
                     :class="{'cursor-not-allowed text-pink-500': uploading || images.length >= uploadLimit}"
                 >
-                    <x-heroicon-o-camera class="h-5 w-5"/>
+                    <x-heroicon-o-photo class="h-5 w-5"/>
                 </button>
             </div>
             @if (! $this->parentId && ! $this->isSharingUpdate)


### PR DESCRIPTION
This is very much a baby PR, but I often thought the upload image icon was misleading. A camera tends to imply that you'll be launching the camera app, as opposed to a file upload prompt.

Twitter, for example, has an image icon to upload media, as opposed to a camera. This change aims to make a tiny but helpful improvement and address potentially incorrect user expectations.

Let me know if you have any questions regarding the motivation behind this tweak.