### PR TITLE
Fix: test suites

### DIFF
--- a/app/Rules/Username.php
+++ b/app/Rules/Username.php
@@ -645,7 +645,7 @@ final readonly class Username implements ValidationRule
             return;
         }
 
-        if (preg_match('/^[A-Za-z0-9_]+$/', $value) === 0) {
+        if (preg_match('/^\w+$/', $value) === 0) {
             $fail('The :attribute may only contain letters, numbers, and underscores.');
 
             return;

--- a/tests/Arch/LivewireTest.php
+++ b/tests/Arch/LivewireTest.php
@@ -13,6 +13,7 @@ arch('livewire components')
     ->toOnlyBeUsedIn([
         'App\Http\Controllers',
         'App\Http\Livewire',
+        'App\Providers\AppServiceProvider',
     ])
     ->ignoring('App\Livewire\Concerns')
     ->not->toUse(['redirect', 'to_route', 'back']);

--- a/tests/Arch/NotificationsTest.php
+++ b/tests/Arch/NotificationsTest.php
@@ -10,4 +10,5 @@ arch('notifications')
         'App\Console\Commands',
         'App\Http\Controllers',
         'App\Observers',
+        'App\Livewire\Notifications\Index',
     ]);

--- a/tests/Unit/Feeds/TrendingQuestionsTest.php
+++ b/tests/Unit/Feeds/TrendingQuestionsTest.php
@@ -18,7 +18,7 @@ it('render questions with right conditions', function () {
             'answer' => 'By modifying the likes in the database :-)',
             'from_id' => $user->id,
             'to_id' => $user->id,
-            'answer_created_at' => now()->subDays(7),
+            'answer_created_at' => now()->subDays(7)->addMinute(),
         ]);
 
     $builder = (new TrendingQuestionsFeed())->builder();

--- a/tests/Unit/Livewire/Home/TrendingTest.php
+++ b/tests/Unit/Livewire/Home/TrendingTest.php
@@ -16,7 +16,7 @@ test('renders trending questions', function () {
     $question = Question::factory()->hasLikes(2)->create([
         'content' => $questionContent,
         'answer' => 'This is the answer',
-        'answer_created_at' => now()->subDays(7),
+        'answer_created_at' => now()->subDays(7)->addMinute(),
         'from_id' => $user->id,
         'to_id' => $user->id,
     ]);

--- a/tests/Unit/Rules/UsernameTest.php
+++ b/tests/Unit/Rules/UsernameTest.php
@@ -42,7 +42,7 @@ test('username validation fails for reserved usernames', function () {
     $fail = fn (string $errorMessage) => throw new InvalidArgumentException($errorMessage);
 
     $rule->validate('username', $reservedUsername, $fail);
-})->throws(InvalidArgumentException::class, 'The username is reserved.');
+})->throws(InvalidArgumentException::class, 'The :attribute is reserved.');
 
 test('username validation fails for existing usernames', function () {
     User::factory()->create(['username' => 'existingUser']);
@@ -52,4 +52,4 @@ test('username validation fails for existing usernames', function () {
     $fail = fn (string $errorMessage) => throw new InvalidArgumentException($errorMessage);
 
     $rule->validate('username', 'existingUser', $fail);
-})->throws(InvalidArgumentException::class, 'The username has already been taken.');
+})->throws(InvalidArgumentException::class, 'The :attribute has already been taken.');


### PR DESCRIPTION
### It fixes
- failing rector in the `Username` rule.
- failing test in `UsernameTest`
- failing arch in `LivewireTest` and `NotificationTest`
- randomly failing `TrendingTest` (run 10 times as it passes all the time, previously it was failing one from three) 