### PR TITLE
Feat(hashtags): Add hashtag autocompletion

### DIFF
--- a/app/Services/Autocomplete.php
+++ b/app/Services/Autocomplete.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Services\Autocomplete\Result;
+use App\Services\Autocomplete\Types\Hashtags;
 use App\Services\Autocomplete\Types\Mentions;
 use App\Services\Autocomplete\Types\Type;
 use Illuminate\Support\Collection;
@@ -18,6 +19,7 @@ final class Autocomplete
      * @var array<string, class-string<Type>>
      */
     private static array $types = [
+        'hashtags' => Hashtags::class,
         'mentions' => Mentions::class,
     ];
 

--- a/app/Services/Autocomplete/Types/Hashtags.php
+++ b/app/Services/Autocomplete/Types/Hashtags.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Autocomplete\Types;
+
+use App\Models\Hashtag;
+use App\Services\Autocomplete\Result;
+use Illuminate\Support\Collection;
+
+final readonly class Hashtags extends Type
+{
+    /**
+     * The delimiter for the autocompletion type.
+     */
+    public function delimiter(): string
+    {
+        return '#';
+    }
+
+    /**
+     * The regular expression that represents a matching
+     * string after the delimiter.
+     */
+    public function matchExpression(): string
+    {
+        return '[a-zA-Z0-9]+';
+    }
+
+    /**
+     * Perform a search using the query to return
+     * autocompletion options.
+     *
+     * @return Collection<int, Result>
+     */
+    public function search(?string $query): Collection
+    {
+        return Hashtag::query()
+            ->withCount('questions')
+            ->where('name', 'like', "$query%")
+            ->orderByDesc('questions_count')
+            ->limit(50)
+            ->get()
+            ->unique(fn (Hashtag $hashtag): string => mb_strtolower($hashtag->name))
+            ->take(8)
+            ->map(fn (Hashtag $hashtag): Result => new Result(
+                id: $hashtag->id,
+                replacement: "#{$hashtag->name}",
+                view: 'components.autocomplete.hashtag-item',
+            ));
+    }
+}

--- a/resources/views/components/autocomplete/hashtag-item.blade.php
+++ b/resources/views/components/autocomplete/hashtag-item.blade.php
@@ -1,0 +1,6 @@
+@php
+    /** @var \App\Services\Autocomplete\Result $result */
+@endphp
+<span class="truncate text-sm font-medium text-slate-50">
+    {{ $result->replacement }}
+</span>

--- a/tests/Unit/Services/Autocomplete/AutocompleteServiceTest.php
+++ b/tests/Unit/Services/Autocomplete/AutocompleteServiceTest.php
@@ -3,13 +3,17 @@
 declare(strict_types=1);
 
 use App\Services\Autocomplete;
+use App\Services\Autocomplete\Types\Hashtags;
 use App\Services\Autocomplete\Types\Mentions;
 use Tests\Fixtures\TestType;
 
 test('types method returns registered autocomplete types', function () {
     $types = Autocomplete::types();
 
-    expect($types)->toBe(['mentions' => Mentions::class]);
+    expect($types)->toBe([
+        'hashtags' => Hashtags::class,
+        'mentions' => Mentions::class,
+    ]);
 });
 
 test('typeClassFor method returns the correct class for a given type', function () {

--- a/tests/Unit/Services/Autocomplete/Types/HashtagsTest.php
+++ b/tests/Unit/Services/Autocomplete/Types/HashtagsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Autocomplete\Types\Hashtags;
+
+it('has the correct delimiter', function () {
+    expect((new Hashtags())->delimiter())->toBe('#');
+});
+
+it('has the correct match expression', function () {
+    expect((new Hashtags())->matchExpression())->toBe('[a-zA-Z0-9]+');
+});
+
+it('returns the correct search results', function () {
+    App\Models\Question::factory()
+        ->sharedUpdate()
+        ->count(7)
+        ->sequence(
+            ['answer' => '#foo'],
+            ['answer' => '#Foo'], // should show #Foo, not #foo, because Foo has more questions_count.
+            ['answer' => '#Foo'],
+            ['answer' => '#fooz'], // #fooz should come first, most questions_count.
+            ['answer' => '#fooz'],
+            ['answer' => '#fooz'],
+            ['answer' => '#bar'], // #bar should not be present in results.
+        )
+        ->create();
+
+    $results = (new Hashtags())->search('f');
+
+    expect($results->pluck('replacement')->all())
+        ->toBe([
+            '#fooz',
+            '#Foo',
+        ]);
+
+    expect((new Hashtags())->search('doesnt_exist'))->toHaveCount(0);
+});


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/afb37ca0-b9f8-4cd7-a2b0-275dc8e3f75e)
![image](https://github.com/user-attachments/assets/0bbc65e4-b13f-4e20-9f58-d5996f5f1c13)
^^^ that pic is just to show that suggestions will have capital letters when relevant. Aka, I'm not forcing a "tolower()" on the strings or anything.

Provides simple autocompletion for hashtags.

1. Will lookup hashtags in a case INsensitive manner. Ie, typing `#fo` would look for hashtags starting with `fo`, `Fo`, `FO`, etc. We have db indexes in place to handle all this efficiently.
2. The autocompletion suggestions will only show non-duplicated hashtags regarding case. So, if `foo` and `Foo` are present in the database, and `foo` has been used 10 times while `Foo` has been used 2 times, only `foo` will appear in the autocomplete suggestions.
3. Suggestions appear in descending order of most used.
4. Suggestions are limited to 8 results. Just a sensible number and keeps a scrollbar from appearing.

Test suite is green. Full coverage.
![image](https://github.com/user-attachments/assets/b8f95dfa-7785-4e2e-9697-13e3383a5c8e)

Closes #371 