### PR TITLE
Fix HashtagFactory to Prevent Duplicate Name Constraint Violations

### DIFF
--- a/database/factories/HashtagFactory.php
+++ b/database/factories/HashtagFactory.php
@@ -23,7 +23,7 @@ final class HashtagFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->word(),
+            'name' => $this->faker->unique()->word(),
         ];
     }
 }

--- a/tests/Unit/Factories/HashtagFactoryTest.php
+++ b/tests/Unit/Factories/HashtagFactoryTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Hashtag;
+
+it('creates a hashtag with a unique name', function () {
+    $hashtags = Hashtag::factory(40)->create();
+
+    $this->assertCount(40, $hashtags);
+    $this->assertEquals(40, $hashtags->unique('name')->count());
+});


### PR DESCRIPTION
### Overview
This pull request fixes an issue with the `HashtagFactory` where non-unique names were being generated, leading to SQL integrity constraint violations due to the unique constraint on the `name` column.

### Changes
- Updated the `HashtagFactory` to use Faker's `unique()` method for generating hashtag names.
- Ensured that all generated names are unique to prevent database errors during testing or seeding.

### Impact
This change resolves the `UniqueConstraintViolationException` error when creating multiple hashtags and ensures smooth database operations when using the factory.
