### PR TITLE
Adds type button to avoid password toggle on Login Page

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -46,7 +46,7 @@
                     autocomplete="current-password"
                 />
                 <div class="absolute inset-y-0 right-0 flex items-center pr-3">
-                    <button x-on:click.prevent="showPassword = !showPassword">
+                    <button type="button" x-on:click="showPassword = !showPassword">
                         <x-icons.eye x-show="showPassword" class="size-5 text-gray-400 hover:text-pink-500" />
                         <x-icons.eye-off x-show="!showPassword" class="size-5 text-gray-400 hover:text-pink-500" />
                     </button>


### PR DESCRIPTION
When logging in, pressing the "Enter" key triggers the password visibility toggle instead of submitting the form as expected. This creates a confusing user experience, as the password visibility is unintentionally toggled when the user tries to log in.

https://github.com/user-attachments/assets/f255588e-8b34-4c47-8e06-6255b7c1e3bc

### Fix:
Updated the password visibility toggle button to include `type="button"`, ensuring that pressing "Enter" submits the form as intended, while the password visibility toggle is now only activated by clicking the button.

https://github.com/user-attachments/assets/e431ddd8-3c2f-4bfa-934a-470878673adb


