### PR TITLE
Fix 593: Border radius mismatch for home.users container

### DIFF
--- a/resources/views/home/users.blade.php
+++ b/resources/views/home/users.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <div class="flex flex-col items-center justify-center">
-        <div class="min-h-screen w-full max-w-md overflow-hidden rounded-2xl px-2 shadow-md sm:px-0">
+        <div class="min-h-screen w-full max-w-md overflow-hidden rounded-lg px-2 shadow-md sm:px-0">
             <x-home-menu></x-home-menu>
 
             <livewire:home.users :focus-input="true" />


### PR DESCRIPTION
Closes #593 

All of the "home" views use `rounded-lg` except `home.users` which accidentally had `rounded-2xl`, which caused the left/right buttons to get clipped.

Before
![image](https://github.com/user-attachments/assets/358a7994-4f6c-4ade-b583-ae26997218c9)

After
<img width="544" alt="image" src="https://github.com/user-attachments/assets/03b10049-e167-424b-b34f-e52ed64138ef">
