### PR TITLE
Avoid profile views increment if user views its own account

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -29,7 +29,9 @@ final readonly class UserController
      */
     public function show(User $user): View
     {
-        IncrementViews::dispatchUsingSession($user);
+        if (auth()->id() !== $user->id) {
+            IncrementViews::dispatchUsingSession($user);
+        }
 
         return view('profile.show', [
             'user' => $user,


### PR DESCRIPTION
To not invalidate numbers, it's better to not increment profile views count when an user views its own account