### PR TITLE
Fix: Broken multi framed visuals on optimization 

### DIFF
--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -294,12 +294,23 @@ final class Create extends Component
         $imagePath = Storage::disk('public')->path($path);
         $imagick = new Imagick($imagePath);
 
-        $imagick->resizeImage(1000, 1000, Imagick::FILTER_LANCZOS, 1, true);
+        if ($imagick->getNumberImages() > 1) {
+            $imagick = $imagick->coalesceImages();
 
-        $imagick->stripImage();
+            foreach ($imagick as $frame) {
+                $frame->resizeImage(1000, 1000, Imagick::FILTER_LANCZOS, 1, true);
+                $frame->stripImage();
+                $frame->setImageCompressionQuality(80);
+            }
 
-        $imagick->setImageCompressionQuality(80);
-        $imagick->writeImage($imagePath);
+            $imagick = $imagick->deconstructImages();
+            $imagick->writeImages($imagePath, true);
+        } else {
+            $imagick->resizeImage(1000, 1000, Imagick::FILTER_LANCZOS, 1, true);
+            $imagick->stripImage();
+            $imagick->setImageCompressionQuality(80);
+            $imagick->writeImage($imagePath);
+        }
 
         $imagick->clear();
         $imagick->destroy();


### PR DESCRIPTION
Fixes broken GIFs and animated WEBPs, and optimizes multi-framed images by detecting whether they have multiple frames or just a static image. It then optimizes the frames or the static image accordingly for formats like JPG, PNG, etc.

Before:

<img width="528" alt="Screenshot 2024-09-15 at 21 53 00" src="https://github.com/user-attachments/assets/42520624-4cf4-452d-9b2c-972abe523c6d">
<img width="551" alt="Screenshot 2024-09-15 at 21 53 39" src="https://github.com/user-attachments/assets/301eba92-4649-4d41-ac19-656184296dfa">

After:


https://github.com/user-attachments/assets/3a92c21f-e422-414c-8d7a-5aa4f2dfcb48

