### PR TITLE
Enhancement: Hashtag trending

### DIFF
--- a/app/EventActions/UpdateQuestionHashtags.php
+++ b/app/EventActions/UpdateQuestionHashtags.php
@@ -6,6 +6,7 @@ namespace App\EventActions;
 
 use App\Models\Hashtag;
 use App\Models\Question;
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -26,8 +27,11 @@ final readonly class UpdateQuestionHashtags
     public function handle(): array
     {
         $parsedHashtags = $this->parsedHashtagNames();
-
+        
         $existingHashtags = Hashtag::query()->whereIn('name', $parsedHashtags->all())->get();
+
+        // Update udated at that particular hashtag used so it should be updated time
+        Hashtag::query()->whereIn('name', $parsedHashtags->all())->update(['updated_at' => Carbon::now()]);
 
         $newHashtags = $parsedHashtags->diff($existingHashtags->pluck('name'))
             ->map(fn (string $name): Hashtag => Hashtag::query()->create(['name' => $name]));

--- a/app/Livewire/Home/TrendingHashtags.php
+++ b/app/Livewire/Home/TrendingHashtags.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Livewire\Home;
+
+use Livewire\Component;
+use App\Queries\Feeds\TrendingHashtags as TrendingHashtagsQuery;
+
+class TrendingHashtags extends Component
+{
+    public function render()
+    {
+        $hashtags = (new TrendingHashtagsQuery())->builder()->limit(5)->orderBy('questions_count', 'DESC')->get();
+        return view('livewire.home.trending-hashtags', ['hashtags' => $hashtags]);
+    }
+}

--- a/app/Livewire/Home/TrendingHashtags.php
+++ b/app/Livewire/Home/TrendingHashtags.php
@@ -4,12 +4,18 @@ namespace App\Livewire\Home;
 
 use Livewire\Component;
 use App\Queries\Feeds\TrendingHashtags as TrendingHashtagsQuery;
+use App\Models\Hashtag;
+use Illuminate\Database\Eloquent\Builder;
 
 class TrendingHashtags extends Component
 {
     public function render()
     {
-        $hashtags = (new TrendingHashtagsQuery())->builder()->limit(5)->orderBy('questions_count', 'DESC')->get();
+        $hashtags = Hashtag::query()
+        ->withCount(['questions' => function (Builder $query) {
+            $query->where('created_at', '>=', now()->subDays(1));
+        }])
+        ->where('updated_at', '>=', now()->subDays(1))->limit(5)->orderBy('questions_count', 'DESC')->get();
         return view('livewire.home.trending-hashtags', ['hashtags' => $hashtags]);
     }
 }

--- a/app/Queries/Feeds/TrendingHashtags.php
+++ b/app/Queries/Feeds/TrendingHashtags.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries\Feeds;
+
+use App\Models\Hashtag;
+use Illuminate\Database\Eloquent\Builder;
+
+final readonly class TrendingHashtags
+{
+
+    /**
+     * The max days since posted for the trending feed.
+     */
+    private const int MAX_DAYS_SINCE_POSTED = 1;
+
+    /**
+     * Get the query builder for the feed.
+     *
+     * @return Builder<Question>
+     */
+    public function builder(): Builder
+    {
+        $maxDaysSincePosted = self::MAX_DAYS_SINCE_POSTED;
+
+        return Hashtag::query()
+            ->withCount('questions')
+            ->where('created_at', '>=', now()->subDays($maxDaysSincePosted));
+    }
+}

--- a/resources/views/home/trending-questions.blade.php
+++ b/resources/views/home/trending-questions.blade.php
@@ -3,6 +3,7 @@
         <div class="w-full max-w-md overflow-hidden rounded-lg px-2 shadow-md sm:px-0">
             <x-home-menu></x-home-menu>
 
+            <livewire:home.trending-hashtags />
             <livewire:home.trending-questions :focus-input="true" />
         </div>
     </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -5,7 +5,7 @@
 
 <nav>
     <div class="{{ $navClasses }}">
-        <div class="flex h-16 justify-between">
+        <div class="flex h-16 md:justify-end bg-pink-500/25 w-full justify-center md:bg-transparent ">
             <div
                 class="flex items-center space-x-2.5"
                 x-data

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -5,7 +5,7 @@
 
 <nav>
     <div class="{{ $navClasses }}">
-        <div class="flex h-16 md:justify-end bg-pink-500/50 w-full justify-center md:bg-transparent ">
+        <div class="flex h-16 md:justify-end bg-slate-900/50 backdrop-blur-sm w-full justify-center md:bg-transparent md:backdrop-blur-none">
             <div
                 class="flex items-center space-x-2.5"
                 x-data

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -5,7 +5,7 @@
 
 <nav>
     <div class="{{ $navClasses }}">
-        <div class="flex h-16 md:justify-end bg-pink-500/25 w-full justify-center md:bg-transparent ">
+        <div class="flex h-16 md:justify-end bg-pink-500/50 w-full justify-center md:bg-transparent ">
             <div
                 class="flex items-center space-x-2.5"
                 x-data

--- a/resources/views/livewire/home/trending-hashtags.blade.php
+++ b/resources/views/livewire/home/trending-hashtags.blade.php
@@ -1,0 +1,5 @@
+<div>
+    @foreach ($hashtags as $hashtag)
+        <a class="bg-slate-600/20 p-4 shadow-2xl backdrop-blur font-medium me-2 py-1 px-2 rounded" href="{{ route('hashtag.show', $hashtag->name) }}">#{{ $hashtag->name }}</a>
+    @endforeach
+</div>

--- a/tests/Unit/Livewire/Home/TrendingTest.php
+++ b/tests/Unit/Livewire/Home/TrendingTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Livewire\Home\TrendingQuestions;
+use App\Livewire\Home\TrendingHashtags;
 use App\Models\Like;
 use App\Models\Question;
 use App\Models\User;
@@ -147,4 +148,21 @@ test('renders trending questions order by trending score', function () {
         'trending question 2',
     ]);
     $component->assertDontSee('trending question 8');
+});
+
+test('render recent most used hashtag', function () {
+    $user = User::factory()->create();
+
+    $questionContent = 'Is this a #trending question?';
+
+    Question::factory()->create([
+        'content' => $questionContent,
+        'answer' => 'No',
+        'from_id' => $user->id,
+    ]);
+
+    $component = Livewire::test(TrendingHashtags::class);
+
+    $component
+        ->assertSee('trending');
 });


### PR DESCRIPTION
Show the top 5 hashtags from the past 24 hours on the trending page. It's clickable and show post based on that hashtag.

![image](https://github.com/user-attachments/assets/f33c4d4a-a1f7-4d38-a02d-6d56612412da)
