### PR TITLE
Allow users to login with username

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -38,5 +41,16 @@ final class FortifyServiceProvider extends ServiceProvider
         });
 
         RateLimiter::for('two-factor', fn (Request $request) => Limit::perMinute(5)->by($request->session()->get('login.id')));
+
+        Fortify::authenticateUsing(function (Request $request) {
+            $user = User::where(fn (Builder $q) => $q->where('email', $request->email)->orWhere('username', $request->email))
+                ->whereNotNull('email_verified_at')
+                ->first();
+
+            if ($user &&
+                Hash::check(type($request->password)->asString(), $user->password)) {
+                return $user;
+            }
+        });
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -9,12 +9,12 @@
         <div>
             <x-input-label
                 for="email"
-                :value="__('Email')"
+                :value="__('Email or Username')"
             />
             <x-text-input
                 id="email"
                 class="mt-1 block w-full"
-                type="email"
+                type="text"
                 name="email"
                 :value="old('email')"
                 required
@@ -33,16 +33,16 @@
                 :value="__('Password')"
             />
 
-            <div 
+            <div
                 class="relative"
-                x-data="{ showPassword: false }" 
+                x-data="{ showPassword: false }"
             >
-                <x-text-input 
-                    id="password" 
-                    class="mt-1 block w-full pr-10" 
+                <x-text-input
+                    id="password"
+                    class="mt-1 block w-full pr-10"
                     x-bind:type="showPassword ? 'text' : 'password'"
                     name="password"
-                    required 
+                    required
                     autocomplete="current-password"
                 />
                 <div class="absolute inset-y-0 right-0 flex items-center pr-3">

--- a/tests/Http/LoginTest.php
+++ b/tests/Http/LoginTest.php
@@ -24,6 +24,34 @@ test('users can authenticate', function () {
     $response->assertRedirect(route('home.feed', absolute: false));
 });
 
+test('users can authenticate with username', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post('/login', [
+        'email' => $user->username,
+        'password' => 'password',
+    ]);
+
+    $this->assertAuthenticated();
+
+    $response->assertRedirect(route('home.feed', absolute: false));
+});
+
+test('user can not authenticate with unverified email', function () {
+    $user = User::factory()->unverified()->create();
+
+    $response = $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $this->assertGuest();
+
+    $response->assertSessionHasErrors([
+        'email' => 'These credentials do not match our records.',
+    ]);
+});
+
 test('users are rate limited', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
Hey Nuno, 

I was surprised to find that login with a username wasn’t supported. This PR adds functionality to allow users to log in using either their email or username.