### PR TITLE
fix: revert navs, use only backdrop-blur instead of light/dark bg

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,11 +1,11 @@
 @php
-    $navClasses = 'fixed z-50 inset-0 h-0 flex md:justify-end md:px-4 ';
+    $navClasses = 'fixed z-50 inset-0 h-16 flex md:justify-end md:px-4 ';
     $navClasses .= auth()->check() ? ' justify-center' : ' justify-end px-4';
 @endphp
 
 <nav>
-    <div class="{{ $navClasses }}">
-        <div class="flex h-16 md:justify-end bg-slate-900/50 backdrop-blur-sm w-full justify-center md:bg-transparent md:backdrop-blur-none">
+    <div class="{{ $navClasses }} backdrop-blur-sm md:backdrop-blur-none">
+        <div class="flex h-16 justify-between">
             <div
                 class="flex items-center space-x-2.5"
                 x-data


### PR DESCRIPTION
- Revert the alignment (justify) to follows the previous styles
- Use backdrop-blur only, not using background so it align between dark/light mode seamlessly

## Signed in (Dark)
#### Mobile
<img width="426" alt="image" src="https://github.com/user-attachments/assets/57a17655-b010-4654-8dad-c14a58480324">

#### Desktop
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/d9b2669d-a12d-4190-a553-365552e40c14">

## Signed in (Light)
#### Mobile
<img width="429" alt="image" src="https://github.com/user-attachments/assets/679b4332-bd7c-4e28-a34e-5397f45e1291">

#### Desktop
<img width="1378" alt="image" src="https://github.com/user-attachments/assets/2ed1641f-67d3-4e15-9e4e-400d94b06922">

## Guest (Dark)
#### Mobile
<img width="435" alt="image" src="https://github.com/user-attachments/assets/564142bb-f4ff-4082-8466-dee5840f57bb">

#### Desktop
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/0451765b-89b5-419c-b5bf-c1e8af00126b">


## Guest (Light)
#### Mobile
<img width="432" alt="image" src="https://github.com/user-attachments/assets/9f321d9a-4e3f-4afd-a02b-1a74a48463d5">

#### Desktop
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/8d44bf41-cfee-4d51-b2ff-3f6cf56e45cf">
