### PR TITLE
fix: missing theme-switch's icon when value of theme is empty string, should set to default theme

### DIFF
--- a/resources/js/theme-switch.js
+++ b/resources/js/theme-switch.js
@@ -11,6 +11,11 @@ const themeSwitch = () => ({
 
         this.modeIndex = this.availableModes.indexOf(currentTheme)
 
+        if (this.modeIndex < 0) {
+            this.setTheme(this.theme)
+            return
+        }
+
         this.setTheme(currentTheme)
     },
 


### PR DESCRIPTION
### Reproduce
1. When local storage value of 'theme' is empty string

<img width="203" alt="image" src="https://github.com/user-attachments/assets/2f258574-7529-476b-b298-cbf0981717eb">

2. Refresh, and the toggle will empty

<img width="304" alt="image" src="https://github.com/user-attachments/assets/8b163cbd-4280-49da-bce3-a91e9bde0edd">

### Fix
1. Set local storage value to empty string
<img width="203" alt="image" src="https://github.com/user-attachments/assets/2f258574-7529-476b-b298-cbf0981717eb">

3. Refresh, now it'll default to 'dark'
<img width="274" alt="image" src="https://github.com/user-attachments/assets/56e837e7-4c4f-4e94-bffe-b9c7c69d1d4f">
