### PR TITLE
Updated Social button redirect on profile

### DIFF
--- a/resources/views/components/links/list-item.blade.php
+++ b/resources/views/components/links/list-item.blade.php
@@ -11,7 +11,7 @@
     href="{{ $link->url }}"
     target="_blank"
     rel="me noopener"
-    class="items-center justify-center px-4 font-bold text-white transition duration-300 ease-in-out"
+    class="items-center justify-center w-full px-4 font-bold text-white transition duration-300 ease-in-out"
 >
     <div class="flex h-full items-center justify-center">
         <p class="truncate">


### PR DESCRIPTION
This is my first contribution. I recently joined Pinkary and believe that there should be a social button to redirect on anywhere click for the sharing link user (guest user on profile). Even though this only one class change, I believe it should, which is why I created this PR.

We can make a condition using $isUserProfileOwner if it feels disturbing for auth profile user.