### PR TITLE
Add space between dropdown links

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -87,6 +87,7 @@
                 <x-dropdown
                     align="right"
                     width="48"
+                    :content-classes="'space-y-1 dark:bg-slate-900 bg-slate-100 dark:border-none border border-slate-100 py-1 text-slate-500'"
                 >
                     <x-slot name="trigger">
                         <button


### PR DESCRIPTION
Add a little space between each link in the Dropdown to make it look better.

Before:
<img width="222" alt="Screenshot 2024-09-20 at 2 52 39 PM" src="https://github.com/user-attachments/assets/470c48c2-7492-4612-b760-413b21b10723">

After:
<img width="222" alt="Screenshot 2024-09-20 at 3 07 18 PM" src="https://github.com/user-attachments/assets/b19b1275-47e8-477b-8d6e-e5f592849723">

