### PR TITLE
Fix: 404 after deleting user

### DIFF
--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -176,9 +176,21 @@ final class Question extends Model implements Viewable
     /**
      * @return BelongsTo<Question, Question>
      */
+    public function root(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'root_id')
+            ->where('is_ignored', false)
+            ->where('is_reported', false);
+    }
+
+    /**
+     * @return BelongsTo<Question, Question>
+     */
     public function parent(): BelongsTo
     {
-        return $this->belongsTo(self::class, 'parent_id');
+        return $this->belongsTo(self::class, 'parent_id')
+            ->where('is_ignored', false)
+            ->where('is_reported', false);
     }
 
     /**

--- a/app/Queries/Feeds/RecentQuestionsFeed.php
+++ b/app/Queries/Feeds/RecentQuestionsFeed.php
@@ -38,6 +38,10 @@ final readonly class RecentQuestionsFeed
                 })->orderByDesc('updated_at');
             }, function (Builder $query): void {
                 $query->select(DB::Raw('IFNULL(root_id, id) as newest_id'), DB::Raw('IFNULL(root_id, id) as id'))
+                    ->where(function (Builder $query): void {
+                        $query->whereNull('root_id')
+                            ->orHas('root');
+                    })
                     ->groupBy('newest_id')
                     ->orderByDesc(DB::raw('MAX(`updated_at`)'));
             });

--- a/tests/Unit/Models/QuestionTest.php
+++ b/tests/Unit/Models/QuestionTest.php
@@ -49,12 +49,15 @@ test('relations', function () {
 
     $child = $question->children()->with('parent')->first();
 
+    $descendant = $question->descendants()->with('root')->first();
+
     expect($question->from)->toBeInstanceOf(User::class)
         ->and($question->to)->toBeInstanceOf(User::class)
         ->and($question->likes)->each->toBeInstanceOf(Like::class)
         ->and($question->hashtags)->each->toBeInstanceOf(Hashtag::class)
         ->and($question->children)->each->toBeInstanceOf(Question::class)
         ->and($child->parent)->toBeInstanceOf(Question::class)
+        ->and($descendant->root)->toBeInstanceOf(Question::class)
         ->and($question->descendants)->each->toBeInstanceOf(Question::class);
 });
 


### PR DESCRIPTION
If a user posts a question and someone comments on it. after that, if the user deletes the account it starts getting 404.

