### PR TITLE
fixe word error on ArchTest file by changin test to arch 

### DIFF
--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -23,7 +23,7 @@ arch('avoid open for extension')
         App\Services\Autocomplete\Types\Type::class,
     ]);
 
-test('ensure no extends')
+arch('ensure no extends')
     ->expect('App')
     ->classes()
     ->not->toBeAbstract()


### PR DESCRIPTION
I've corrected a small error by replacing the word test with arch in the ArchTest.php file. 
I hope this will be my first contribution to a major project. 😊😊😊😊😊😊