### PR TITLE
Refactor TrendingQuestions to use simplePaginate instead of paginate

### DIFF
--- a/app/Livewire/Home/TrendingQuestions.php
+++ b/app/Livewire/Home/TrendingQuestions.php
@@ -19,7 +19,7 @@ final class TrendingQuestions extends Component
      */
     public function render(Request $request): View
     {
-        $questions = (new TrendingQuestionsFeed())->builder()->paginate($this->perPage);
+        $questions = (new TrendingQuestionsFeed())->builder()->simplePaginate($this->perPage);
 
         return view('livewire.home.trending-questions', [
             'trendingQuestions' => $questions,


### PR DESCRIPTION
Matching other feeds (Also it will add a little performance boost by skipping count query which is a bit costly here).