### PR TITLE
Theme switch label

### DIFF
--- a/resources/js/theme-switch.js
+++ b/resources/js/theme-switch.js
@@ -1,5 +1,5 @@
 const themeSwitch = () => ({
-    
+
     theme: 'dark', // default theme
 
     availableModes: ['dark', 'light'], // e.g. system
@@ -52,15 +52,14 @@ const themeSwitch = () => ({
 
     toggleTheme() {
         const newModeIndex = (this.modeIndex + 1) % this.availableModes.length
-        
+
         this.modeIndex = newModeIndex
         this.setTheme(this.availableModes[newModeIndex])
     },
 
     toggleThemeButtonText() {
-        return this.theme.charAt(0).toUpperCase() + this.theme.slice(1)
+        return this.availableModes.filter((mode) => mode !== this.theme)[0]
     }
-
 })
 
 export { themeSwitch }

--- a/resources/js/theme-switch.js
+++ b/resources/js/theme-switch.js
@@ -58,7 +58,8 @@ const themeSwitch = () => ({
     },
 
     toggleThemeButtonText() {
-        return this.availableModes.filter((mode) => mode !== this.theme)[0]
+        let themeLabel = this.availableModes.filter((mode) => mode !== this.theme)[0]
+        return themeLabel.charAt(0).toUpperCase() + themeLabel.slice(1)
     }
 })
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -101,8 +101,8 @@
                         <x-dropdown-button x-data="themeSwitch()" @click="toggleTheme" class="flex flex-row items-center justify-between">
                             <span x-text="toggleThemeButtonText"></span>
                             <span class="mr-2">
-                                <x-heroicon-o-moon x-show="theme == 'dark'" class="h-4 w-4"/>
-                                <x-heroicon-o-sun x-show="theme == 'light'" class="h-4 w-4"/>
+                                <x-heroicon-o-moon x-show="theme == 'light'" class="h-4 w-4"/>
+                                <x-heroicon-o-sun x-show="theme == 'dark'" class="h-4 w-4"/>
                                 <x-heroicon-o-computer-desktop x-show="theme == 'system'" class="h-4 w-4"/>
                             </span>
                         </x-dropdown-button>


### PR DESCRIPTION
Its a minor fix to show light option in dark and vice versa.
as of now it shows the same label as the selected theme.

![image](https://github.com/user-attachments/assets/0936e4b6-591f-4656-8a70-64475b7ddbc0)
