### PR TITLE
Feat: threads in following

### DIFF
--- a/resources/views/components/thread.blade.php
+++ b/resources/views/components/thread.blade.php
@@ -6,37 +6,40 @@
     'username' => null,
 ])
 
-<div>
+<div wire:key="thread-{{ $questionId.'-'.$rootId.'-'.$parentId }}">
     @if ($rootId !== null)
         <livewire:questions.show
             :questionId="$rootId"
             :in-thread="true"
-            :key="$rootId"
+            :key="'question-'.$rootId"
         />
     @endif
     @if ($parentId !== null && $rootId !== $parentId)
-        @if ($grandParentId === $rootId)
-            <x-post-divider />
-        @else
-            <x-post-divider
-                :link="route('questions.show', ['username' => $username, 'question' => $rootId])"
-                :text="'View more comments...'"
-            />
+        @if($rootId !== null)
+            @if ($grandParentId === $rootId)
+                <x-post-divider wire:key="divider-{{ $parentId }}" />
+            @else
+                <x-post-divider
+                    :link="route('questions.show', ['username' => $username, 'question' => $questionId])"
+                    :text="'View more comments...'"
+                    wire:key="divider-{{ $parentId }}"
+                />
+            @endif
         @endif
         <livewire:questions.show
             :questionId="$parentId"
-            :in-thread="true"
-            :key="$parentId"
+            :in-thread="$rootId !== null"
+            :key="'question-'.$parentId"
         />
     @endif
-
     @if ($parentId !== null || $rootId !== null)
-        <x-post-divider />
+        <x-post-divider
+            wire:key="divider-{{ $questionId }}"
+        />
     @endif
-
     <livewire:questions.show
         :questionId="$questionId"
-        :in-thread="true"
-        :key="$questionId"
+        :in-thread="$rootId !== null || $parentId !== null"
+        :key="'question-'.$questionId"
     />
 </div>

--- a/resources/views/livewire/home/questions-following.blade.php
+++ b/resources/views/livewire/home/questions-following.blade.php
@@ -8,11 +8,12 @@
     @else
         <section class="mb-12 min-h-screen space-y-10">
             @foreach ($followingQuestions as $question)
-                <livewire:questions.show
+                <x-thread
+                    :rootId="$question->showRoot ? $question->root_id : null"
+                    :grandParentId="$question->grand_parent_id"
+                    :parentId="$question->showParent ? $question->parent_id : null"
                     :questionId="$question->id"
-                    :key="'question-' . $question->id"
-                    :inIndex="true"
-                    :pinnable="false"
+                    :username="$question->username"
                 />
             @endforeach
 

--- a/tests/Unit/Livewire/Home/FeedTest.php
+++ b/tests/Unit/Livewire/Home/FeedTest.php
@@ -133,7 +133,7 @@ test('refresh', function () {
 
 it('renders the threads in the right order', function () {
 
-    // create 5 roots
+    // create 4 roots
     $roots = Question::factory()
         ->forEachSequence(
             ['answer' => 'root 1'],

--- a/tests/Unit/Livewire/Home/FollowingTest.php
+++ b/tests/Unit/Livewire/Home/FollowingTest.php
@@ -12,7 +12,7 @@ test('renders questions with follow of authenticated user', function () {
 
     $questionContent = 'This is a question with a follow from the authenticated user';
 
-    $question = Question::factory()->create([
+    Question::factory()->create([
         'content' => $questionContent,
         'answer' => 'Cool question',
         'from_id' => $user->id,
@@ -69,4 +69,99 @@ test('load more', function () {
     }
 
     $component->assertSet('perPage', 100);
+});
+
+it('renders the threads in the right order', function () {
+
+    $user = User::factory()->create();
+    $anotherUser = User::factory()->create();
+    $authUser = User::factory()->create();
+
+    $authUser->following()->attach($user->id);
+    $authUser->following()->attach($anotherUser->id);
+
+    $answerForFollowingUser = 'following user question';
+    $answerForAnotherFollowingUser = 'another following user question';
+    $answerForAuthUser = 'auth user question';
+    $answerForNonFollowingUser = 'non following user post';
+
+    $questions = Question::factory()
+        ->forEachSequence(
+            ['answer' => $answerForFollowingUser, 'to_id' => $user->id],
+            ['answer' => $answerForAnotherFollowingUser, 'to_id' => $anotherUser->id],
+            ['answer' => $answerForAuthUser, 'to_id' => $authUser->id],
+            ['answer' => $answerForNonFollowingUser],
+        )->create();
+
+    // create a child for each following user's question
+    $questions->each(function (Question $question) use ($answerForNonFollowingUser) {
+
+        $this->travel(1)->seconds();
+
+        Question::factory()->sharedUpdate()->create([
+            'answer' => '1st child question for '.str($question->answer)->snake(),
+            'root_id' => $question->id,
+            'parent_id' => $question->id,
+            'to_id' => $question->where('answer', '!=', $answerForNonFollowingUser)->inRandomOrder()->first()->to_id,
+        ]);
+    });
+
+    $questions->load('children');
+
+    // create a root without descendants
+    $this->travel(1)->seconds();
+    Question::factory()->sharedUpdate()->create(['answer' => 'root without descendants', 'to_id' => $user->id]); // by following user
+
+    // create a child for each child of even roots
+    $questions->filter(fn (Question $question, int $key) => ($key + 1) % 2 === 0) // evens
+        ->each(function (Question $question) use ($answerForNonFollowingUser) {
+            $this->travel(1)->seconds();
+
+            Question::factory()->sharedUpdate()->create([
+                'answer' => '2nd nested child question for '.str($question->answer)->snake(),
+                'parent_id' => $question->children->first()->id,
+                'root_id' => $question->id,
+                'to_id' => $question->where('answer', '!=', $answerForNonFollowingUser)->inRandomOrder()->first()->to_id, // random following user
+            ]);
+        });
+
+    $this->travel(1)->seconds();
+
+    // 3rd nested child question for another following user question, it's 1st child should be missing in the feed
+    Question::factory()->sharedUpdate()->create([
+        'answer' => '3rd nested child question for '.str($answerForAnotherFollowingUser)->snake(),
+        'root_id' => $questions->where('answer', $answerForAnotherFollowingUser)->first()->id,
+        'parent_id' => Question::where('answer', '2nd nested child question for '.str($answerForAnotherFollowingUser)->snake())->first()->id,
+        'to_id' => $authUser->id,
+    ]);
+
+    // 3rd nested child question for non following user question from non following user should be missing in the feed
+    Question::factory()->sharedUpdate()->create([
+        'answer' => '3rd nested child question for '.str($answerForNonFollowingUser)->snake(),
+        'root_id' => $questions->where('answer', $answerForNonFollowingUser)->first()->id,
+        'parent_id' => Question::where('answer', '2nd nested child question for '.str($answerForNonFollowingUser)->snake())->first()->id,
+    ]);
+
+    $component = Livewire::actingAs($authUser)->test(QuestionsFollowing::class);
+
+    // final output needs to be root without descendants divided odds and evens in descending order
+    // 1st child question for another following user question should be missing
+    // answers for non following user should be missing
+    // 3rd nested child question for auth user should be missing
+    $component->assertSeeInOrder([
+        $answerForAnotherFollowingUser,
+        '2nd nested child question for '.str($answerForAnotherFollowingUser)->snake(),
+        '3rd nested child question for '.str($answerForAnotherFollowingUser)->snake(),
+        '1st child question for '.str($answerForNonFollowingUser)->snake(),
+        '2nd nested child question for '.str($answerForNonFollowingUser)->snake(),
+        'root without descendants',
+        $answerForAuthUser,
+        '1st child question for '.str($answerForAuthUser)->snake(),
+        $answerForFollowingUser,
+        '1st child question for '.str($answerForFollowingUser)->snake(),
+    ]);
+
+    $component->assertDontSee('1st child question for '.str($answerForAnotherFollowingUser)->snake());
+    $component->assertDontSee($answerForNonFollowingUser);
+    $component->assertDontSee('3rd nested child question for '.str($answerForAuthUser)->snake());
 });


### PR DESCRIPTION
### Following Feed Logic for Displaying Posts and Comments

The feed will primarily display posts and comments from users that the current user is following, or from the current user themselves. Here's a breakdown of how posts and comments are shown:

1. Posts by Following Users (or Self):
   - If the root post (main post) is by a user the current user is following, it will be displayed in the feed.
   
2. Comments on Posts:
   - If a post (root) is not by a following user, but the parent (comment) is by a following user, only the comment and parent will be shown, not the original post.
   - If the root post is by a following user and the comment (parent) is not, only the root post and the comment will be displayed.
   - If both the root post and the parent comment are by users the current user is not following, neither will be shown.

https://github.com/user-attachments/assets/75b84143-b3fc-4670-a5e4-b3e5abf4a062

