### PR TITLE
Fix: #656 Better handling of 'select' for autocomplete with no options

### DIFF
--- a/resources/js/autocomplete.js
+++ b/resources/js/autocomplete.js
@@ -77,8 +77,10 @@ export const autocomplete = (config) => ({
     },
 
     select(replacement) {
+        replacement ??= this.getReplacementFromSelectedResult() ?? this.activeToken.word;
+
         Livewire.dispatch('autocompleteSelected', {
-            newValue: this.formatReplacement(replacement ?? this.getReplacementFromSelectedResult())
+            newValue: this.formatReplacement(replacement)
         })
 
         this.activeToken = false;


### PR DESCRIPTION
Closes #656 

Before
https://github.com/user-attachments/assets/98c5dc98-c1b0-4f6a-917e-66833d7f9a09

After
https://github.com/user-attachments/assets/8c471543-3161-493c-8455-0010b88ac0c3

