### PR TITLE
Limit the answers length to 50 characters in page title

### DIFF
--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -151,7 +151,7 @@
     />
 
     @if ($answer)
-        <title>{{ $question->to->name }}: "{!! $answer !!}" / Pinkary</title>
+        <title>{{ $question->to->name }}: "{!! Str::limit($answer, 50, preserveWords: true) !!}" / Pinkary</title>
         <meta
             property="og:title"
             content='{{ $ogTitle }}'


### PR DESCRIPTION
Currently, the title shows the full answer in title.

The same title goes by default when a user bookmarks any of the post in their browser.

For a readable title, limiting the title to just 50 characters.

This will respect the SEO limits of the titles for 70 characters as well leaving room for username and "Pinkary" branding 