### PR TITLE
fix: add error handling for QR code generation

### DIFF
--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -9,6 +9,8 @@ use Illuminate\Http\Request;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
 use SimpleSoftwareIO\QrCode\Generator;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use SimpleSoftwareIO\QrCode\Exceptions\InvalidArgumentException;
+use SimpleSoftwareIO\QrCode\Exceptions\RuntimeException;
 
 final readonly class QrCodeController
 {
@@ -38,9 +40,12 @@ final readonly class QrCodeController
                 ->generate(route('profile.show', [
                     'username' => $user->username,
                 ]));
+        } catch (InvalidArgumentException $e) {
+            return response()->json(['error' => 'Invalid QR code parameters: ' . $e->getMessage()], 400);
+        } catch (RuntimeException $e) {
+            return response()->json(['error' => 'QR code generation failed: ' . $e->getMessage()], 500);
         } catch (\Exception $e) {
-            // Handle the error appropriately
-            return response()->json(['error' => 'Failed to generate QR code'], 500);
+            return response()->json(['error' => 'Unexpected error during QR code generation'], 500);
         }
 
         return response()->streamDownload(

--- a/app/Http/Controllers/QrCodeController.php
+++ b/app/Http/Controllers/QrCodeController.php
@@ -26,17 +26,22 @@ final readonly class QrCodeController
         $dark = [3, 7, 18, 100];
         $bgColor = $request->query('theme') === 'light' ? $light : $dark;
 
-        $qrCode = $qrCodeGenerator
-            ->margin(2)
-            ->size(512)
-            ->format('png')
-            ->backgroundColor(...$bgColor)
-            ->color(236, 72, 153, 100)
-            ->merge('/public/img/ico.png')
-            ->errorCorrection('M')
-            ->generate(route('profile.show', [
-                'username' => $user->username,
-            ]));
+        try {
+            $qrCode = $qrCodeGenerator
+                ->margin(2)
+                ->size(512)
+                ->format('png')
+                ->backgroundColor(...$bgColor)
+                ->color(236, 72, 153, 100)
+                ->merge('/public/img/ico.png')
+                ->errorCorrection('M')
+                ->generate(route('profile.show', [
+                    'username' => $user->username,
+                ]));
+        } catch (\Exception $e) {
+            // Handle the error appropriately
+            return response()->json(['error' => 'Failed to generate QR code'], 500);
+        }
 
         return response()->streamDownload(
             function () use ($qrCode): void {


### PR DESCRIPTION
This pull request addresses an issue in the QrCodeController where potential exceptions during QR code generation were not being handled. I have added a try-catch block around the QR code generation logic to handle potential exceptions in `app/Http/Controllers/QrCodeController.php`