### PR TITLE
feat: added member since date to profile page

### DIFF
--- a/resources/views/livewire/links/index.blade.php
+++ b/resources/views/livewire/links/index.blade.php
@@ -158,6 +158,11 @@
             >
         @endif
 
+        <div class="flex flex-row items-center justify-center text-slate-500 pt-1.5 gap-0.5">
+            <x-heroicon-o-calendar-days class="size-5"/>
+            <p class="text-sm">Since {{ $user->created_at->format('M Y') }}</p>
+        </div>
+
         <livewire:followers.index :userId="$user->id" />
         <livewire:following.index :userId="$user->id" />
 


### PR DESCRIPTION
This pull request adds a "Since" date to the user profile page, showing when a user first joined. It gives users a quick view of their account history and adds a nice personal touch to the profile.