### PR TITLE
Fix: Handle case where image markdown insert passes 1000 chars

### DIFF
--- a/resources/js/image-upload.js
+++ b/resources/js/image-upload.js
@@ -2,6 +2,7 @@ const imageUpload = () => ({
     uploading: false,
     uploadLimit: null,
     maxFileSize: null,
+    maxContentLength: null,
     images: [],
     errors: [],
     textarea: null,

--- a/resources/js/image-upload.js
+++ b/resources/js/image-upload.js
@@ -139,6 +139,7 @@ const imageUpload = () => ({
         );
         this.removeMarkdownImage(index);
         this.images.splice(index, 1);
+        this.errors = [];
     },
 
     createMarkdownImage(item) {

--- a/resources/js/image-upload.js
+++ b/resources/js/image-upload.js
@@ -149,10 +149,21 @@ const imageUpload = () => ({
         } else if (typeof item === 'number') {
             ({path, originalName} = this.images[item]);
         }
-        this.insertAtCorrectPosition(
-            `![${originalName}](${this.normalizePath(path)})`,
-        );
+
+        const markdownSnippet = `![${originalName}](${this.normalizePath(path)})`;
+
+        if (this.isExceedingMaxContentLength(markdownSnippet)) {
+            this.addErrors(['Adding this image will exceed the maximum content length.']);
+            return;
+        }
+
+        this.insertAtCorrectPosition(markdownSnippet);
         this.uploading = false;
+    },
+
+    isExceedingMaxContentLength(markdownSnippet) {
+        const newLength = this.textarea.value.length + markdownSnippet.length;
+        return newLength > this.maxContentLength;
     },
 
     escapeRegExp(string) {

--- a/resources/js/image-upload.js
+++ b/resources/js/image-upload.js
@@ -35,7 +35,7 @@ const imageUpload = () => ({
 
         Livewire.on('question.created', () => {
             this.images = [];
-            this.errors = [];
+            this.removeErrors();
         });
 
         Livewire.hook('morph.updated', ({el, component}) => {
@@ -82,9 +82,13 @@ const imageUpload = () => ({
         });
     },
 
+    removeErrors() {
+        this.errors = [];
+    },
+
     checkFileSize(files) {
         if (files.length) {
-            this.errors = [];
+            this.removeErrors();
             Array.from(files).forEach((file) => {
                 if ((file.size / 1024) > this.maxFileSize) {
                     this.addErrors([`The image may not be greater than ${this.maxFileSize} kilobytes.`]);
@@ -139,7 +143,7 @@ const imageUpload = () => ({
         );
         this.removeMarkdownImage(index);
         this.images.splice(index, 1);
-        this.errors = [];
+        this.removeErrors();
     },
 
     createMarkdownImage(item) {
@@ -156,6 +160,10 @@ const imageUpload = () => ({
         if (this.isExceedingMaxContentLength(markdownSnippet)) {
             this.addErrors(['Adding this image will exceed the maximum content length.']);
             return;
+        }
+
+        if (this.errors.length > 0) {
+            this.removeErrors();
         }
 
         this.insertAtCorrectPosition(markdownSnippet);

--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -10,6 +10,7 @@
         x-init='() => {
             uploadLimit = {{ $this->uploadLimit }};
             maxFileSize = {{ $this->maxFileSize }};
+            maxContentLength = {{ $this->maxContentLength }};
         }'
     >
         <div


### PR DESCRIPTION
We currently have an edge case, where if the user has a post that is close to the max content length & they upload an image, there is no current validation, which allows the user to exceed the content limit.

<img width="636" alt="Screenshot 2024-09-27 at 11 25 38 AM" src="https://github.com/user-attachments/assets/e2121c29-eb12-4ad7-a698-203fb22b34f0">

This PR will add a check to ensure that the image being inserted as markdown won't pass the content limit & the image preview will still be available for the user to click and try to re-insert the markdown once the post has been shortened.

Closes #508

https://github.com/user-attachments/assets/7e38ccc8-7549-4ebb-9d7c-ceb438db86d4