### PR TITLE
Fixes always showing "Follow me on Pinkary" when sharing another user

### DIFF
--- a/resources/views/livewire/links/index.blade.php
+++ b/resources/views/livewire/links/index.blade.php
@@ -44,7 +44,7 @@
                         x-on:click="
                             twitter({
                                 url: '{{ route('profile.show', ['username' => $user->username]) }}',
-                                message: 'Follow me on Pinkary',
+                                message: {{ auth()->user()?->is($user) ? 'Follow me on Pinkary' : "Follow {$user->name} on Pinkary" }},
                             })
                         "
                         type="button"

--- a/tests/Unit/Livewire/Links/IndexTest.php
+++ b/tests/Unit/Livewire/Links/IndexTest.php
@@ -109,6 +109,30 @@ test('guest or random user cannot see qr download link', function () {
     $component->assertDontSee(route('qr-code.image'));
 });
 
+test('user can share to twitter link', function () {
+    $user = User::factory()->create();
+
+    $component = Livewire::actingAs($user)->test(Index::class, [
+        'userId' => $user->id,
+    ]);
+
+    $component->assertSee(route('profile.show', ['username' => $user->username]));
+    $component->assertSee('Follow me on Pinkary');
+});
+
+test('guest or random user can share another user twitter link', function () {
+    $user = User::factory()->create();
+
+    $randomUser = User::factory()->create();
+
+    $component = Livewire::actingAs($randomUser)->test(Index::class, [
+        'userId' => $user->id,
+    ]);
+
+    $component->assertSee(route('profile.show', ['username' => $user->username]));
+    $component->assertSee("Follow {$user->name} on Pinkary");
+});
+
 test('when user click his own links the clicks counter is not incremented', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
This PR fixes the "Follow me on Pinkary" when sharing another user.

# From clicking on the **X**:
<img width="203" alt="image" src="https://github.com/user-attachments/assets/63d91047-f2f3-487e-9b79-78c140db1d4f">

## Before
<img width="663" alt="image" src="https://github.com/user-attachments/assets/9282880c-1566-456d-a2ad-c9d371fca9c8">

## After
<img width="641" alt="image" src="https://github.com/user-attachments/assets/a52a5248-ce25-422b-b41f-39316ca79baf">
