### PR TITLE
fix: nav being in front of things on wider displays

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,5 +1,5 @@
 @php
-    $navClasses = 'fixed z-50 inset-0 h-16 flex md:justify-end md:px-4 ';
+    $navClasses = 'fixed z-50 inset-0 md:inset-auto md:right-0 h-16 flex md:justify-end md:px-4 ';
     $navClasses .= auth()->check() ? ' justify-center' : ' justify-end px-4';
 @endphp
 


### PR DESCRIPTION
This PR fixes a minor bug. I wasn't able to click on the back button when seeing a post, so i figured it was the nav blocking the button on wider displays

![Pinkary-OneLink AllYourSocials -30September2024](https://github.com/user-attachments/assets/7ddedb95-1182-4515-bed3-22de8b19a006)


Now it is fixed

![Pinkary-OneLink AllYourSocials -30September20242](https://github.com/user-attachments/assets/81a493eb-a44d-4f7a-b9f7-5c9cd3062ab6)

Please let me know if not being able to click was the intended behavior, because if it is, i think it needs some visual cue that the nav is being spanned through the whole width of the screen