### PR TITLE
changed notification position to bottom left.

### DIFF
--- a/resources/views/livewire/flash-messages/show.blade.php
+++ b/resources/views/livewire/flash-messages/show.blade.php
@@ -14,7 +14,7 @@ x-data="{
 >
     <div
         id="flashMessageWrapper"
-        class="fixed right-4 top-4 z-50 w-64 space-y-2"
+        class="fixed left-4 bottom-4 z-50 w-64 space-y-2"
     ></div>
 
     <template id="flashMessageTemplate">


### PR DESCRIPTION
changed notification position to bottom left from top right. All the social media use bottom left corner for the notification display. Facebook, linkedin to name some. It also give a more aesthetic look to the notification being not below the menus.

![SCR-20241005-becw](https://github.com/user-attachments/assets/353cb7f5-9cbd-44f4-b0e3-3b5d9814219c)
