### PR TITLE
Adds a test for the optimizeImage function with an image that includes multiple frames so that overall code coverage is 100%

### DIFF
--- a/tests/Unit/Livewire/Questions/CreateTest.php
+++ b/tests/Unit/Livewire/Questions/CreateTest.php
@@ -523,6 +523,62 @@ test('optimizeImage method resizes and saves the image', function () {
         ->and($image->height())->toBeLessThanOrEqual(1000);
 });
 
+test('optimizeImage method resizes and saves image with multiple frames', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+
+    $gif = new Imagick();
+
+    $gif->setFormat('gif');
+
+    for ($i = 0; $i < 3; $i++) {
+        $frame = new Imagick();
+
+        $frame->newImage(1200, 1200, new ImagickPixel(match ($i) {
+            0 => 'red',
+            1 => 'green',
+            2 => 'blue',
+        }));
+
+        $frame->setImageFormat('gif');
+
+        $gif->addImage($frame);
+    }
+
+    $testImage = UploadedFile::fake()->createWithContent('test.gif', $gif->getImagesBlob());
+
+    $path = $testImage->store('images', 'public');
+
+    $component = Livewire::actingAs($user)->test(Create::class, [
+        'toId' => $user->id,
+    ]);
+
+    $component->call('optimizeImage', $path);
+
+    Storage::disk('public')->assertExists($path);
+
+    $optimizedImagePath = Storage::disk('public')->path($path);
+
+    $originalImageSize = filesize($testImage->getPathname());
+    $optimizedImageSize = filesize($optimizedImagePath);
+
+    expect($optimizedImageSize)->toBeLessThan($originalImageSize);
+
+    $optimizedImage = new Imagick($optimizedImagePath);
+
+    expect($optimizedImage->getImageWidth())->toBeLessThanOrEqual(1000)
+        ->and($optimizedImage->getImageHeight())->toBeLessThanOrEqual(1000)
+        ->and($optimizedImage->getNumberImages())->toBe(3);
+
+    $frames = $optimizedImage->coalesceImages();
+
+    foreach ($frames as $frame) {
+        expect($frame->getImageWidth())->toBeLessThanOrEqual(1000)
+            ->and($frame->getImageHeight())->toBeLessThanOrEqual(1000);
+    }
+});
+
 test('maxFileSize and maxImages', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
Currently the `composer test:unit` script fails because coverage is not 100%. This results in all GitHub action runs failing. This PR adds a test that covers the non-tested code path