### PR TITLE
Fix: handle whitespace issue in codeblocks

### DIFF
--- a/app/Services/ParsableContentProviders/CodeProviderParsable.php
+++ b/app/Services/ParsableContentProviders/CodeProviderParsable.php
@@ -16,12 +16,12 @@ final readonly class CodeProviderParsable implements ParsableContentProvider
     public function parse(string $content): string
     {
         return (string) preg_replace_callback(
-            '/```(?<language>[a-z]+)?\n(?<code>.*?)\n```/s',
+            '/```(?<language>[a-z]+)?\s*\n(?<code>.*?)\n```/s',
             function (array $matches): string {
                 $code = $matches['code'];
                 $language = empty($matches['language'])
                     ? 'plaintext'
-                    : $matches['language'];
+                    : trim($matches['language']);
 
                 $highlighter = new Highlighter();
 

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -267,6 +267,19 @@ test('code', function (string $content) {
             ```
             EOL,
     ],
+    /*
+        The below example tests that the code block is still parsed correctly
+        even if there is a space after the language. Sonarlint flags up a 'useless space' error
+        so we need to use a str_replace to add a space after the language programatically.
+    */
+    [
+        'content' => str_replace('```php', '```php ', <<<'EOL'
+            ```php
+            echo "Hello, World!";
+            ```
+            EOL
+        ),
+    ],
 ]);
 
 test('mention', function (string $content) {

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -268,8 +268,8 @@ test('code', function (string $content) {
             EOL,
     ],
     /*
-        The below example tests that the code block is still parsed correctly
-        even if there is a space after the language. Sonarlint flags up a 'useless space' error
+        The below example tests that the code block is still parsed correctly even if there
+        is a space after the language. Sonarlint flags up a 'useless space' error
         so we need to use a str_replace to add a space after the language programatically.
     */
     [


### PR DESCRIPTION
Fixes #672 

This change makes a small amendment to the `parse()` function to handle a user submitting a codeblock and accidentally including whitespace after the language declaration. 

The test passes and creates a snapshot - I've not seen the snapshot stuff before in my career so I'm not sure if I was supposed to commit those files too. Happy to do so if that is necessary 👍 