### PR TITLE
Make "Bio" field not required

### DIFF
--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -116,7 +116,6 @@
                 type="text"
                 class="mt-1 block w-full"
                 :value="old('bio', $user->bio)"
-                required
                 autocomplete="bio"
             />
             <x-input-error


### PR DESCRIPTION
When registering you are not required to fill in your "Bio" data. It then does not make sense to make it a required field when editing your profile (and in fact the field is nullable and is not required in the backend when calling the patch profile route). You may be just editing your profile to change something else like your email preferences and be forced to enter something in this field.

This PR just removes this "required" property from the blade template to make it not required on the frontend.

This description is much longer than the fix itself 🤣 