### PR TITLE
fix: mentions list not showing on the edit mode

### DIFF
--- a/app/Livewire/Autocomplete.php
+++ b/app/Livewire/Autocomplete.php
@@ -19,6 +19,11 @@ use Livewire\Component;
 final class Autocomplete extends Component
 {
     /**
+     * The component id used for scoping events.
+     */
+    public string $componentId = '';
+
+    /**
      * An array of matched type aliases (like ["mentions", ...]).
      *
      * @var array<int, string>

--- a/resources/js/autocomplete.js
+++ b/resources/js/autocomplete.js
@@ -1,4 +1,5 @@
 export const autocomplete = (config) => ({
+    componentId: null,
     types: null,
     matchedTypes: null,
     showAutocompleteOptions: false,
@@ -8,16 +9,17 @@ export const autocomplete = (config) => ({
     listeners: [],
 
     init() {
+        this.componentId = config.componentId;
         this.types = config.types;
         this.initListeners();
     },
 
     initListeners() {
-        this.listeners.push(Livewire.on('autocompleteBoundInputKeyup', (payload) => {this.handleInput(payload)}));
-        this.listeners.push(Livewire.on('autocompleteBoundInputArrowUp', (event) => this.focusResultsUp()));
-        this.listeners.push(Livewire.on('autocompleteBoundInputArrowDown', (event) => this.focusResultsDown()));
-        this.listeners.push(Livewire.on('selectAutocomplete', (event) => this.select()));
-        this.listeners.push(Livewire.on('closeAutocompletePanel', (event) => this.closeResults()));
+        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputKeyup`, (payload) => {this.handleInput(payload)}));
+        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputArrowUp`, (event) => this.focusResultsUp()));
+        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputArrowDown`, (event) => this.focusResultsDown()));
+        this.listeners.push(Livewire.on(`${this.componentId}:selectAutocomplete`, (event) => this.select()));
+        this.listeners.push(Livewire.on(`${this.componentId}:closeAutocompletePanel`, (event) => this.closeResults()));
     },
 
     handleInput(payload) {
@@ -79,7 +81,7 @@ export const autocomplete = (config) => ({
     select(replacement) {
         replacement ??= this.getReplacementFromSelectedResult() ?? this.activeToken.word;
 
-        Livewire.dispatch('autocompleteSelected', {
+        Livewire.dispatch(`${this.componentId}:autocompleteSelected`, {
             newValue: this.formatReplacement(replacement)
         })
 
@@ -116,13 +118,13 @@ export const autocomplete = (config) => ({
 
     openResults() {
         this.showAutocompleteOptions = true;
-        Livewire.dispatch('autocompletePanelShown');
+        Livewire.dispatch(`${this.componentId}:autocompletePanelShown`);
     },
 
     closeResults() {
         this.showAutocompleteOptions = false;
         this.selectedIndex = 0;
-        Livewire.dispatch('autocompletePanelClosed');
+        Livewire.dispatch(`${this.componentId}:autocompletePanelClosed`);
     },
 
     focusResultsUp() {
@@ -152,14 +154,14 @@ export const autocomplete = (config) => ({
     },
 });
 
-export const usesAutocomplete = () => ({
+export const usesAutocomplete = (componentId) => ({
     autocompletePanelIsShown: false,
     listeners: [],
 
     init() {
-        Livewire.on('autocompletePanelShown', () => this.autocompletePanelIsShown = true);
-        Livewire.on('autocompletePanelClosed', () => this.autocompletePanelIsShown = false);
-        Livewire.on('autocompleteSelected', (event) => {
+        Livewire.on(`${componentId}:autocompletePanelShown`, () => this.autocompletePanelIsShown = true);
+        Livewire.on(`${componentId}:autocompletePanelClosed`, () => this.autocompletePanelIsShown = false);
+        Livewire.on(`${componentId}:autocompleteSelected`, (event) => {
             this.$focus.focus(this.$el);
 
             this.$nextTick(() => {
@@ -171,7 +173,7 @@ export const usesAutocomplete = () => ({
 
     autocompleteInputBindings: {
         ['@keyup.debounce.250ms'](event) {
-            Livewire.dispatch('autocompleteBoundInputKeyup', {
+            Livewire.dispatch(`${componentId}:autocompleteBoundInputKeyup`, {
                 content: this.$el.value,
                 event: event,
             })
@@ -179,37 +181,37 @@ export const usesAutocomplete = () => ({
         ['@keydown.arrow-up'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch('autocompleteBoundInputArrowUp')
+                Livewire.dispatch(`${componentId}:autocompleteBoundInputArrowUp`)
             }
         },
         ['@keydown.arrow-down'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch('autocompleteBoundInputArrowDown')
+                Livewire.dispatch(`${componentId}:autocompleteBoundInputArrowDown`)
             }
         },
         ['@keydown.enter'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch('selectAutocomplete')
+                Livewire.dispatch(`${componentId}:selectAutocomplete`)
             }
         },
         ['@keydown.tab'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch('selectAutocomplete')
+                Livewire.dispatch(`${componentId}:selectAutocomplete`)
             }
         },
         ['@keydown.escape'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch('closeAutocompletePanel')
+                Livewire.dispatch(`${componentId}:closeAutocompletePanel`)
             }
         },
         ['@click.away'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch('closeAutocompletePanel')
+                Livewire.dispatch(`${componentId}:closeAutocompletePanel`)
             }
         },
     },

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -1,8 +1,11 @@
-@props(['autocomplete' => false])
+@props(['autocomplete' => false, 'id' => null])
+@php
+    $componentId = $id ?? Str::uuid();
+@endphp
 <textarea
     {!! $attributes->merge(['class' => 'w-full dark:text-white text-black dark:caret-white caret-black focus:border-pink-500 dark:border-slate-800 border-slate-300 dark:bg-slate-900/50 bg-slate-50/50 backdrop-blur-sm dark:focus:ring-slate-900 focus:ring-slate-100 rounded-lg shadow-sm sm:text-sm']) !!}
     @if ($autocomplete === true)
-        x-data="usesDynamicAutocomplete"
+        x-data="usesDynamicAutocomplete('{{ $componentId }}')"
         x-bind="autocompleteInputBindings"
     @endif
 >
@@ -10,5 +13,5 @@
 </textarea>
 
 @if ($autocomplete === true)
-<livewire:autocomplete></livewire:autocomplete>
+<livewire:autocomplete :componentId="$componentId"></livewire:autocomplete>
 @endif

--- a/resources/views/livewire/autocomplete.blade.php
+++ b/resources/views/livewire/autocomplete.blade.php
@@ -1,5 +1,5 @@
 <div
-    x-data="dynamicAutocomplete({ types: @js($this->autocompleteTypes) })"
+    x-data="dynamicAutocomplete({ types: @js($this->autocompleteTypes), componentId: '{{ $componentId }}' })"
     x-cloak
     x-show="showAutocompleteOptions"
 >

--- a/resources/views/livewire/questions/edit.blade.php
+++ b/resources/views/livewire/questions/edit.blade.php
@@ -1,4 +1,4 @@
-<div class="border-l dark:border-slate-900 border-slate-200">
+<div>
     <form wire:submit="update">
         <div class="mt-4 flex items-center justify-between">
             <div class="w-full">
@@ -9,7 +9,7 @@
                         >Answer</label
                     >
 
-                    <textarea
+                    <x-textarea
                         id="{{ 'answer_question_'.$question->id }}"
                         wire:model="answer"
                         x-autosize
@@ -17,7 +17,8 @@
                         placeholder="Write your answer..."
                         maxlength="1000"
                         rows="3"
-                    ></textarea>
+                        autocomplete
+                    ></x-textarea>
 
                     <p class="text-right text-xs text-slate-400"><span x-text="$wire.answer.length"></span> / 1000</p>
 


### PR DESCRIPTION
This PR fixes #685 

When editing a post, the mention list was not being shown:
![ezgif-3-2f2c5ebf49](https://github.com/user-attachments/assets/81cfe1d7-5452-4ebf-9030-e4f879656ef5)

Now it's fixed:
![ezgif-3-7d282cf5b1](https://github.com/user-attachments/assets/91f74350-ac9d-46d1-bb5d-b7b3305af5f9)


There are 2 ways of fixing this imo without changing too much of the code. One is making an entire component just for the editing textarea, and the other one is using the same textarea blade component that already existed for the question creation. I chose the latter, but I needed the events to be scoped to the blade component, because if it wasn't, the edit textarea would trigger the autocomplete on the creation textarea and vice versa because the it assumed that only 1 component of that type would exist at a time as it emits and listens for global Livewire events.

And i removed the styling of the edit blade component because it was not really matching the styling of the textarea blade component.

If anyone knows a better way to scope the events or to fix this issue, please let me know, i would gladly change my implementation to better fit the codebase.