### PR TITLE
fix: overflowing issue when opening the last dropdown menu

### DIFF
--- a/resources/views/livewire/questions/index.blade.php
+++ b/resources/views/livewire/questions/index.blade.php
@@ -1,4 +1,4 @@
-<section class="mt-4 space-y-10">
+<section class="mt-4 space-y-10 mb-12">
     @if ($pinnedQuestion)
         <livewire:questions.show
             :questionId="$pinnedQuestion->id"

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <div class="flex flex-col items-center justify-center py-10">
-        <div class="min-h-screen w-full max-w-md overflow-hidden rounded-lg px-4 dark:shadow-md md:px-0">
+        <div class="min-h-screen w-full max-w-md overflow-hidden rounded-lg px-4 md:px-0">
             <livewire:links.index :userId="$user->id" />
             <livewire:questions.create :toId="$user->id" />
             <livewire:questions.index


### PR DESCRIPTION
This PR fixes #696 

The menu was being hidden on the overflow-hidden of a parent div, there are some solutions, but I chose the most non-destructive one that was to just add a margin-bottom to give space to the dropdown menu.

Now it's fixed:
![ezgif-3-71ae5ab365](https://github.com/user-attachments/assets/8ab3e47a-e3e6-46ef-8936-a98764d43148)

I also removed the shadow that was on that parent div because the shadows would be displaced after the margin addition and was adding a thin "border" to the div even before this