### PR TITLE
Fix: Bump Vite - Vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
         "postcss": "^8.4.38",
         "sortablejs": "^1.15.2",
         "tailwindcss": "^3.4.3",
-        "vite": "^5.0"
+        "vite": "5.4.6"
     }
 }


### PR DESCRIPTION
There are 2 reported vulnerabilities in the current Vite version in package.json.

Bumping to 5.4.6 will handle patching this.

2 vulnerabilities found in dependency:
GHSA-64vr-g452-qvp3 - Vite DOM Clobbering gadget found in vite bundled scripts that leads to XSS
GHSA-9cwx-2883-4wfx - Vite's `server. fs. deny` is bypassed when using `?import&raw`