### PR TITLE
Refactor model relationship annotations to use 'covariant $this'

### DIFF
--- a/app/Models/Bookmark.php
+++ b/app/Models/Bookmark.php
@@ -27,7 +27,7 @@ final class Bookmark extends Model
     /**
      * The question that the bookmark belongs to.
      *
-     * @return BelongsTo<Question, $this>
+     * @return BelongsTo<Question, covariant $this>
      */
     public function question(): BelongsTo
     {
@@ -37,7 +37,7 @@ final class Bookmark extends Model
     /**
      * The user that the bookmark belongs to.
      *
-     * @return BelongsTo<User, $this>
+     * @return BelongsTo<User, covariant $this>
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Hashtag.php
+++ b/app/Models/Hashtag.php
@@ -37,7 +37,7 @@ final class Hashtag extends Model
     }
 
     /**
-     * @return BelongsToMany<Question, $this>
+     * @return BelongsToMany<Question, covariant $this>
      */
     public function questions(): BelongsToMany
     {

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -27,7 +27,7 @@ final class Like extends Model
     /**
      * The question that the like belongs to.
      *
-     * @return BelongsTo<Question, $this>
+     * @return BelongsTo<Question, covariant $this>
      */
     public function question(): BelongsTo
     {
@@ -37,7 +37,7 @@ final class Like extends Model
     /**
      * The user that the like belongs to.
      *
-     * @return BelongsTo<User, $this>
+     * @return BelongsTo<User, covariant $this>
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -28,7 +28,7 @@ final class Link extends Model
     /**
      * Get the user that owns the link.
      *
-     * @return BelongsTo<User, $this>
+     * @return BelongsTo<User, covariant $this>
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -106,7 +106,7 @@ final class Question extends Model implements Viewable
     /**
      * Get the user that the question was sent from.
      *
-     * @return BelongsTo<User, $this>
+     * @return BelongsTo<User, covariant $this>
      */
     public function from(): BelongsTo
     {
@@ -116,7 +116,7 @@ final class Question extends Model implements Viewable
     /**
      * Get the user that the question was sent to.
      *
-     * @return BelongsTo<User, $this>
+     * @return BelongsTo<User, covariant $this>
      */
     public function to(): BelongsTo
     {
@@ -126,7 +126,7 @@ final class Question extends Model implements Viewable
     /**
      * Get the bookmarks for the question.
      *
-     * @return HasMany<Bookmark, $this>
+     * @return HasMany<Bookmark, covariant $this>
      */
     public function bookmarks(): HasMany
     {
@@ -136,7 +136,7 @@ final class Question extends Model implements Viewable
     /**
      * Get the likes for the question.
      *
-     * @return HasMany<Like, $this>
+     * @return HasMany<Like, covariant $this>
      */
     public function likes(): HasMany
     {
@@ -174,7 +174,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return BelongsTo<Question, $this>
+     * @return BelongsTo<Question, covariant $this>
      */
     public function root(): BelongsTo
     {
@@ -184,7 +184,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return BelongsTo<Question, $this>
+     * @return BelongsTo<Question, covariant $this>
      */
     public function parent(): BelongsTo
     {
@@ -194,7 +194,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return HasMany<Question, $this>
+     * @return HasMany<Question, covariant $this>
      */
     public function children(): HasMany
     {
@@ -204,7 +204,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return HasMany<Question, $this>
+     * @return HasMany<Question, covariant $this>
      */
     public function descendants(): HasMany
     {
@@ -214,7 +214,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return BelongsToMany<Hashtag, $this>
+     * @return BelongsToMany<Hashtag, covariant $this>
      */
     public function hashtags(): BelongsToMany
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -100,7 +100,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's bookmarks.
      *
-     * @return HasMany<Bookmark, $this>
+     * @return HasMany<Bookmark, covariant $this>
      */
     public function bookmarks(): HasMany
     {
@@ -110,7 +110,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's links.
      *
-     * @return HasMany<Link, $this>
+     * @return HasMany<Link, covariant $this>
      */
     public function links(): HasMany
     {
@@ -120,7 +120,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's questions sent.
      *
-     * @return HasMany<Question, $this>
+     * @return HasMany<Question, covariant $this>
      */
     public function questionsSent(): HasMany
     {
@@ -130,7 +130,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's questions received.
      *
-     * @return HasMany<Question, $this>
+     * @return HasMany<Question, covariant $this>
      */
     public function questionsReceived(): HasMany
     {
@@ -138,7 +138,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     }
 
     /**
-     * @return HasOne<Question, $this>
+     * @return HasOne<Question, covariant $this>
      */
     public function pinnedQuestion(): HasOne
     {
@@ -149,7 +149,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's followers.
      *
-     * @return BelongsToMany<User, $this>
+     * @return BelongsToMany<User, covariant $this>
      */
     public function followers(): BelongsToMany
     {
@@ -159,7 +159,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's following.
      *
-     * @return BelongsToMany<User, $this>
+     * @return BelongsToMany<User, covariant $this>
      */
     public function following(): BelongsToMany
     {


### PR DESCRIPTION
Update model relationship annotations to improve type safety and clarity by using `covariant $this` in the return types.

This will ensure phpstan to pass.

More info here: https://phpstan.org/blog/whats-up-with-template-covariant#call-site-variance

Related to: https://github.com/phpstan/phpstan/issues/11857