### PR TITLE
test: enhance HTTP fake responses and add metadata parsing tests

### DIFF
--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -113,6 +113,7 @@ final readonly class MetaData
                 if (mb_strtolower($meta->getAttribute('name')) === 'description') {
                     $data->put('description', $meta->getAttribute('content'));
                 }
+
                 if (mb_strtolower($meta->getAttribute('name')) === 'keywords') {
                     $data->put('keywords', $meta->getAttribute('content'));
                 }
@@ -168,6 +169,7 @@ final readonly class MetaData
                     'maxwidth' => '446',
                     'maxheight' => '251',
                 ]);
+
             if ($youtube->isNotEmpty()) {
                 foreach ($youtube as $key => $value) {
                     $data->put($key, $value);

--- a/tests/Unit/Models/QuestionTest.php
+++ b/tests/Unit/Models/QuestionTest.php
@@ -31,6 +31,9 @@ test('to array', function () {
 });
 
 test('content', function () {
+    Http::sequence()
+        ->whenEmpty(Http::response('', 404));
+
     $question = Question::factory()->create([
         'content' => 'Hello https://example.com, how are you? https://example.com',
     ])->fresh();

--- a/tests/Unit/Models/QuestionTest.php
+++ b/tests/Unit/Models/QuestionTest.php
@@ -31,8 +31,9 @@ test('to array', function () {
 });
 
 test('content', function () {
-    Http::sequence()
-        ->whenEmpty(Http::response('', 404));
+    Http::fake([
+        '*' => Http::response('', 404),
+    ]);
 
     $question = Question::factory()->create([
         'content' => 'Hello https://example.com, how are you? https://example.com',

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 use Illuminate\Http\UploadedFile;
 
 beforeEach(function () {
-    Http::sequence()
-        ->whenEmpty(Http::response('', 404));
+    Http::fake([
+        '*' => Http::response('', 404),
+    ]);
 });
 
 test('brs', function (string $content, string $parsed) {

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Http\UploadedFile;
 
+beforeEach(function () {
+    Http::sequence()
+        ->whenEmpty(Http::response('', 404));
+});
+
 test('brs', function (string $content, string $parsed) {
     $provider = new App\Services\ParsableContentProviders\BrProviderParsable();
 

--- a/tests/Unit/Services/ContentTest.php
+++ b/tests/Unit/Services/ContentTest.php
@@ -7,6 +7,10 @@ test('link', function () {
 
     $provider = new App\Services\ParsableContent();
 
+    Http::fake([
+        'https://example.com' => Http::response('', 404),
+    ]);
+
     expect($provider->parse($content))
         ->toMatchSnapshot();
 });
@@ -15,6 +19,19 @@ test('only links with images or html oEmbeds are parsed', function () {
     $content = 'Sure, here is the link: https://laravel.com. Let me know if you have any questions.';
 
     $provider = new App\Services\ParsableContent();
+
+    Http::fake([
+        'https://laravel.com' => Http::response('
+            <html>
+                <head>
+                    <meta property="og:title" content="Laravel - The PHP Framework For Web Artisans">
+                    <meta property="og:type" content="website">
+                    <meta property="og:url" content="https://laravel.com/">
+                    <meta property="og:image" content="https://laravel.com/img/og-image.jpg">
+                </head>
+            </html>
+        ', 200),
+    ]);
 
     expect($provider->parse($content))
         ->toMatchSnapshot();
@@ -34,7 +51,19 @@ it('ignores mention inside <a>', function () {
 
     $provider = new App\Services\ParsableContent();
 
+    Http::fake([
+        'https://pinkary.com/@nunomaduro' => Http::response('
+            <html>
+                <head>
+                    <meta property="og:title" content="Nuno Maduro (@nunomaduro) / Pinkary">
+                    <meta property="og:type" content="profile">
+                    <meta property="og:url" content="https://pinkary.com/@nunomaduro">
+                    <meta property="og:image" content="https://pinkary.com/storage/avatars/120f8d175fd0146ca0541625b8bd6c742e838632951a7e58dc7fbdc8c2170c4f.png">
+                </head>
+            </html>
+        ', 200),
+    ]);
+
     expect($provider->parse($content))
         ->toMatchSnapshot();
-
 });

--- a/tests/Unit/Services/MetaDataTest.php
+++ b/tests/Unit/Services/MetaDataTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Services\MetaData;
+use GuzzleHttp\Promise\RejectedPromise;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
@@ -15,9 +17,25 @@ it('returns the cached meta data if it exists', function () {
     $cachedData = collect([
         'title' => 'Laravel - The PHP Framework For Web Artisans',
         'description' => 'Laravel is a PHP web application framework with expressive, elegant syntax. We’ve already laid the foundation — freeing you to create without sweating the small things.',
+        'keywords' => 'artisan, laravel, php, web, framework, taylor otwell',
         'type' => 'website',
         'url' => 'https://laravel.com/',
         'image' => 'https://laravel.com/img/og-image.jpg',
+    ]);
+
+    Http::fake([
+        $url => Http::response('
+            <html>
+                <head>
+                    <meta name="title" content="Laravel - The PHP Framework For Web Artisans">
+                    <meta name="description" content="Laravel is a PHP web application framework with expressive, elegant syntax. We&rsquo;ve already laid the foundation &mdash; freeing you to create without sweating the small things.">
+                    <meta name="keywords" content="artisan, laravel, php, web, framework, taylor otwell">
+                    <meta property="og:type" content="website">
+                    <meta property="og:url" content="https://laravel.com/">
+                    <meta property="og:image" content="https://laravel.com/img/og-image.jpg">
+                </head>
+            </html>
+        ', 200),
     ]);
 
     $service = new MetaData($url);
@@ -30,6 +48,36 @@ it('returns the cached meta data if it exists', function () {
 it('gets the youtube oembed data', function () {
     $url = 'https://youtu.be/emMYyeBfYlM';
     $cacheKey = Str::of($url)->slug()->prepend('preview_')->value();
+
+    Http::fake([
+        $url => Http::response('
+            <html>
+                <head>
+                    <meta property="og:title" content="Migrating Brent&rsquo;s PHPUnit Test Suite to Pest">
+                    <meta property="og:type" content="video">
+                    <meta property="og:url" content="https://www.youtube.com/watch?v=emMYyeBfYlM">
+                    <meta property="og:image" content="https://i.ytimg.com/vi/emMYyeBfYlM/maxresdefault.jpg">
+                    <meta property="og:site_name" content="YouTube">
+                </head>
+            </html>
+        ', 200),
+        'www.youtube.com/oembed?url=*' => Http::response([
+            'title' => 'Migrating Brent’s PHPUnit Test Suite to Pest',
+            'author_name' => 'Nuno Maduro',
+            'author_url' => 'https://www.youtube.com/@nunomaduro',
+            'type' => 'video',
+            'height' => 113,
+            'width' => 200,
+            'version' => '1.0',
+            'provider_name' => 'YouTube',
+            'provider_url' => 'https://www.youtube.com/',
+            'thumbnail_height' => 360,
+            'thumbnail_width' => 480,
+            'thumbnail_url' => 'https://i.ytimg.com/vi/emMYyeBfYlM/hqdefault.jpg',
+            'html' => '<iframe width="200" height="113" src="https://www.youtube.com/embed/emMYyeBfYlM?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen title="Migrating Brent’s PHPUnit Test Suite to Pest"></iframe>',
+        ], 200),
+    ]);
+
     $service = new MetaData($url);
     $data = $service->fetch();
 
@@ -42,6 +90,34 @@ it('gets the youtube oembed data', function () {
 it('gets the twitter oembed data', function () {
     $url = 'https://x.com/enunomaduro/status/1845794776886493291';
     $cacheKey = Str::of($url)->slug()->prepend('preview_')->value();
+
+    Http::fake([
+        $url => Http::response('
+            <html>
+                <head>
+                    <meta name="twitter:title" content="Migrating Brent&rsquo;s PHPUnit Test Suite to Pest">
+                    <meta name="twitter:description" content="I&rsquo;ve been using PHPUnit for years. But recently, I&rsquo;ve been migrating my test suite to Pest. Here&rsquo;s why and how I did it.">
+                    <meta name="twitter:image" content="https://pbs.twimg.com/media/Exv6J9zWYAI1Z1-.jpg">
+                    <meta name="twitter:url" content="https://twitter.com/enunomaduro/status/1845794776886493291">
+                    <meta name="twitter:card" content="summary_large_image">
+                    <meta name="og:site_name" content="X (formerly Twitter)">
+                </head>
+            </html>
+        ', 200),
+        'publish.twitter.com/oembed?url=*' => Http::response([
+            'url' => 'https://twitter.com/enunomaduro/status/1845794776886493291',
+            'author_name' => 'Nuno Maduro',
+            'author_url' => 'https://twitter.com/enunomaduro',
+            'html' => '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">I’ve been using PHPUnit for years. But recently, I’ve been migrating my test suite to Pest. Here’s why and how I did it.</p>&mdash; Nuno Maduro (@enunomaduro) <a href="https://twitter.com/enunomaduro/status/1845794776886493291?ref_src=twsrc%5Etfw">April 6, 2021</a></blockquote>',
+            'width' => 550,
+            'height' => 550,
+            'type' => 'rich',
+            'cache_age' => '3153600000',
+            'provider_name' => 'Twitter',
+            'provider_url' => 'https://twitter.com',
+        ], 200),
+    ]);
+
     $service = new MetaData($url);
     $data = $service->fetch();
 
@@ -53,6 +129,36 @@ it('gets the twitter oembed data', function () {
 it('gets the vimdeo oembed data', function () {
     $url = 'https://vimeo.com/76979871';
     $cacheKey = Str::of($url)->slug()->prepend('preview_')->value();
+
+    Http::fake([
+        $url => Http::response('
+            <html>
+                <head>
+                    <meta property="og:title" content="The Long Goodbye">
+                    <meta property="og:type" content="video">
+                    <meta property="og:url" content="https://vimeo.com/76979871">
+                    <meta property="og:image" content="https://i.vimeocdn.com/video/449392997_1280.jpg">
+                    <meta property="og:site_name" content="Vimeo">
+                </head>
+            </html>
+        ', 200),
+        'vimeo.com/oembed?url=*' => Http::response([
+            'title' => 'The Long Goodbye',
+            'author_name' => 'Ane Brun',
+            'author_url' => 'https://vimeo.com/user1957130',
+            'type' => 'video',
+            'height' => 281,
+            'width' => 500,
+            'version' => '1.0',
+            'provider_name' => 'Vimeo',
+            'provider_url' => 'https://vimeo.com/',
+            'thumbnail_height' => 360,
+            'thumbnail_width' => 640,
+            'thumbnail_url' => 'https://i.vimeocdn.com/video/449392997_1280.jpg',
+            'html' => '<iframe src="https://player.vimeo.com/video/76979871" width="500" height="281" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen title="The Long Goodbye"></iframe>',
+        ], 200),
+    ]);
+
     $service = new MetaData($url);
     $data = $service->fetch();
 
@@ -72,4 +178,39 @@ it('returns an empty collection if the HTTP request fails', function () {
     $data = $service->fetch();
 
     expect($data->isEmpty())->toBeTrue();
+});
+
+it('returns an empty collection if a ConnectionException is thrown', function () {
+    $url = 'https://aurlthatdoesnotexist.com';
+
+    Http::fake([
+        $url => fn ($request) => new RejectedPromise(new ConnectionException('Connection error')),
+    ]);
+
+    $service = new MetaData($url);
+    $data = $service->fetch();
+
+    expect($data->isEmpty())->toBeTrue();
+
+    $url = 'https://youtu.be/emMYyeBfYlM';
+
+    Http::fake([
+        $url => Http::response('
+            <html>
+                <head>
+                    <meta property="og:title" content="Migrating Brent&rsquo;s PHPUnit Test Suite to Pest">
+                    <meta property="og:type" content="video">
+                    <meta property="og:url" content="https://www.youtube.com/watch?v=emMYyeBfYlM">
+                    <meta property="og:image" content="https://i.ytimg.com/vi/emMYyeBfYlM/maxresdefault.jpg">
+                    <meta property="og:site_name" content="YouTube">
+                </head>
+            </html>
+        ', 200),
+        'www.youtube.com/oembed?url=*' => fn ($request) => new RejectedPromise(new ConnectionException('Connection error')),
+    ]);
+
+    $service = new MetaData($url);
+    $data = $service->fetch();
+
+    expect($data->has('html'))->toBeFalse();
 });


### PR DESCRIPTION
This PR fixes Slow tests

## Before
![image](https://github.com/user-attachments/assets/b1713110-6282-4c53-ac3a-b1ab4ec6518e)

## After
![image](https://github.com/user-attachments/assets/e5262bda-5466-4bb4-8ca1-e9497333647a)
