### PR TITLE
fix: update regex to include <div> tags in hashtag parsing

### DIFF
--- a/app/Services/ParsableContentProviders/HashtagProviderParsable.php
+++ b/app/Services/ParsableContentProviders/HashtagProviderParsable.php
@@ -15,7 +15,7 @@ final readonly class HashtagProviderParsable implements ParsableContentProvider
     public function parse(string $content): string
     {
         return (string) preg_replace_callback(
-            '/(<(a|code|pre)\s+[^>]*>.*?<\/\2>)|(?<!&)#([a-z0-9]+)/is',
+            '/(<(a|code|pre|div)\s+[^>]*>.*?<\/\2>)|(?<!&)#([a-z0-9]+)/is',
             function (array $matches): string {
                 if ($matches[1] !== '') {
                     return $matches[1];


### PR DESCRIPTION
## before
![image](https://github.com/user-attachments/assets/1f06176f-4bfc-4014-a37e-c2c693f18695)
## after
![image](https://github.com/user-attachments/assets/5653abc9-aeee-4c07-b888-f24202f528fb)
