### PR TITLE
Fix: Add Existence & image size check + add Twitterbot user-agent for x.com

### DIFF
--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -14,6 +14,16 @@ use Illuminate\Support\Str;
 final readonly class MetaData
 {
     /**
+     * The width of the preview card.
+     */
+    private const int CARD_WIDTH = 446;
+
+    /**
+     * The height of the preview card.
+     */
+    private const int CARD_HEIGHT = 251;
+
+    /**
      * Fetch the Open Graph data for a given URL.
      */
     public function __construct(private string $url)
@@ -132,8 +142,8 @@ final readonly class MetaData
             $vimeo = $this->fetchOEmbed(
                 service: 'https://vimeo.com/api/oembed.json',
                 options: [
-                    'maxwidth' => '446',
-                    'maxheight' => '251',
+                    'maxwidth' => self::CARD_WIDTH,
+                    'maxheight' => self::CARD_HEIGHT,
                 ]
             );
             if ($vimeo->isNotEmpty()) {
@@ -147,8 +157,8 @@ final readonly class MetaData
             $youtube = $this->fetchOEmbed(
                 service: 'https://www.youtube.com/oembed',
                 options: [
-                    'maxwidth' => '446',
-                    'maxheight' => '251',
+                    'maxwidth' => self::CARD_WIDTH,
+                    'maxheight' => self::CARD_HEIGHT,
                 ]);
 
             if ($youtube->isNotEmpty()) {

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -187,11 +187,10 @@ final readonly class MetaData
 
         $data = $this->parseContent($html);
 
+        $isSuitable = true;
+
         if ($data->has('image')) {
             $isSuitable = $this->checkExistsAndSize((string) $data->get('image'));
-            if (! $isSuitable) {
-                $data->forget('image');
-            }
         }
 
         if ($data->has('site_name') && $data->get('site_name') === 'X (formerly Twitter)') {
@@ -201,11 +200,12 @@ final readonly class MetaData
                 $data = $this->parseContent($response->body());
                 if ($data->has('image')) {
                     $isSuitable = $this->checkExistsAndSize((string) $data->get('image'));
-                    if (! $isSuitable) {
-                        $data->forget('image');
-                    }
                 }
             }
+        }
+
+        if (! $isSuitable) {
+            $data->forget('image');
         }
 
         if ($data->has('site_name') && $data->get('site_name') === 'Vimeo') {

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -16,12 +16,12 @@ final readonly class MetaData
     /**
      * The width of the preview card.
      */
-    private const int CARD_WIDTH = 446;
+    public const int CARD_WIDTH = 446;
 
     /**
      * The height of the preview card.
      */
-    private const int CARD_HEIGHT = 251;
+    public const int CARD_HEIGHT = 251;
 
     /**
      * Fetch the Open Graph data for a given URL.

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -194,6 +194,20 @@ final readonly class MetaData
             }
         }
 
+        if ($data->has('site_name') && $data->get('site_name') === 'X (formerly Twitter)') {
+            $response = Http::withHeader('User-Agent', 'Twitterbot')->get($this->url);
+
+            if ($response->ok()) {
+                $data = $this->parseContent($response->body());
+                if ($data->has('image')) {
+                    $isSuitable = $this->checkExistsAndSize((string) $data->get('image'));
+                    if (! $isSuitable) {
+                        $data->forget('image');
+                    }
+                }
+            }
+        }
+
         if ($data->has('site_name') && $data->get('site_name') === 'Vimeo') {
             $vimeo = $this->fetchOEmbed(
                 service: 'https://vimeo.com/api/oembed.json',

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -49,6 +49,23 @@ final readonly class MetaData
     }
 
     /**
+     * Ensure the correct size for an oEmbed iframe.
+     */
+    public function ensureCorrectSize(string $value): string
+    {
+        $doc = new DOMDocument();
+        @$doc->loadHTML($value);
+        $iframe = $doc->getElementsByTagName('iframe')->item(0);
+        if ($iframe) {
+            $iframe->setAttribute('width', (string) self::CARD_WIDTH);
+            $iframe->setAttribute('height', (string) self::CARD_HEIGHT);
+
+            return (string) $doc->saveHTML($iframe);
+        }
+
+        return $value;
+    }
+    /**
      * Get the meta-data for a given URL.
      *
      * @return Collection<string, string>
@@ -101,7 +118,7 @@ final readonly class MetaData
      *
      * @return Collection<string, string>
      */
-    private function parse(string $content): Collection
+    private function parseContent(string $content): Collection
     {
         $doc = new DOMDocument();
         @$doc->loadHTML($content);
@@ -148,7 +165,9 @@ final readonly class MetaData
             );
             if ($vimeo->isNotEmpty()) {
                 foreach ($vimeo as $key => $value) {
-                    $data->put($key, $value);
+                    $key === 'html'
+                        ? $data->put($key, $this->ensureCorrectSize((string) $value))
+                        : $data->put($key, $value);
                 }
             }
         }
@@ -163,7 +182,9 @@ final readonly class MetaData
 
             if ($youtube->isNotEmpty()) {
                 foreach ($youtube as $key => $value) {
-                    $data->put($key, $value);
+                    $key === 'html'
+                        ? $data->put($key, $this->ensureCorrectSize((string) $value))
+                        : $data->put($key, $value);
                 }
             }
         }

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -51,8 +51,7 @@ final readonly class MetaData
             $response = Http::get($this->url);
 
             if ($response->ok()) {
-                $data = $this->parse($response->body())
-                    ->filter(fn (string $value): bool => $value !== '');
+                $data = $this->parse($response->body());
             }
         } catch (ConnectionException) {
             // Catch but not capture the exception
@@ -64,7 +63,7 @@ final readonly class MetaData
     /**
      * Fetch the oEmbed data for a given URL.
      *
-     * @param  array<string, string>  $options
+     * @param  array<string, string|int>  $options
      * @return Collection<string, string>
      */
     private function fetchOEmbed(string $service, array $options): Collection
@@ -79,8 +78,6 @@ final readonly class MetaData
             if ($response->ok()) {
                 /** @var Collection<string, string|null> $data */
                 $data = $response->collect();
-                $data = $data
-                    ->filter(fn (?string $value): bool => (string) $value !== '');
             }
         } catch (ConnectionException) {
             // Catch but not capture the exception
@@ -130,6 +127,7 @@ final readonly class MetaData
             }
         }
 
+        return $data->filter(fn (?string $value): bool => (string) $value !== '');
         if ($data->has('site_name') && $data->get('site_name') === 'Vimeo') {
             $vimeo = $this->fetchOEmbed(
                 service: 'https://vimeo.com/api/oembed.json',


### PR DESCRIPTION
Add several enhancements and small refactors to the `MetaData` service, focusing on ensuring existence & image dimension check in the handling of OG image previews. Also ensures that the oEmbed iframes are the correct size too.
Additionally, new tests have been added to cover these changes.

* Added constants for preview card dimensions to `MetaData` class (`CARD_WIDTH` and `CARD_HEIGHT`).
* Introduced `ensureCorrectSize` method to set the correct size for oEmbed iframes.
* Added `checkExistsAndSize` method to validate the existence and size of images.
* Refactored `parse` method to include image validation and handle special cases for "X (formerly Twitter)".

Now it will show a normal image preview for X/twitter only if the tweet has an image or video that is used as the og:image & that image is large enough to be displayed will.

<img width="550" alt="Screenshot 2024-11-05 at 7 48 16 PM" src="https://github.com/user-attachments/assets/ce14b7a8-ba11-4a54-98e9-9a7965964204">
<img width="550" alt="Screenshot 2024-11-05 at 7 48 30 PM" src="https://github.com/user-attachments/assets/98847c2c-105f-4057-b432-c96d6a479af7">
