### PR TITLE
Fix: image security

### DIFF
--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -264,35 +264,6 @@ final class Create extends Component
     }
 
     /**
-     * Handle the image uploads.
-     */
-    public function uploadImages(): void
-    {
-        collect($this->images)->each(function (UploadedFile $image): void {
-            $today = now()->format('Y-m-d');
-
-            /** @var string $path */
-            $path = $image->store("images/{$today}", 'public');
-            $this->optimizeImage($path);
-
-            if ($path) {
-                session()->push('images', $path);
-
-                $this->dispatch(
-                    'image.uploaded',
-                    path: Storage::url($path),
-                    originalName: $image->getClientOriginalName()
-                );
-            } else { // @codeCoverageIgnoreStart
-                $this->addError('images', 'The image could not be uploaded.');
-                $this->dispatch('notification.created', message: 'The image could not be uploaded.');
-            } // @codeCoverageIgnoreEnd
-        });
-
-        $this->reset('images');
-    }
-
-    /**
      * Optimize the images.
      */
     public function optimizeImage(string $path): void
@@ -323,15 +294,6 @@ final class Create extends Component
     }
 
     /**
-     * Handle the image deletes.
-     */
-    public function deleteImage(string $path): void
-    {
-        Storage::disk('public')->delete($path);
-        $this->cleanSession($path);
-    }
-
-    /**
      * Render the component.
      */
     public function render(): View
@@ -345,6 +307,44 @@ final class Create extends Component
         return view('livewire.questions.create', [
             'user' => $user,
         ]);
+    }
+
+    /**
+     * Handle the image deletes.
+     */
+    private function deleteImage(string $path): void
+    {
+        Storage::disk('public')->delete($path);
+        $this->cleanSession($path);
+    }
+
+    /**
+     * Handle the image uploads.
+     */
+    private function uploadImages(): void
+    {
+        collect($this->images)->each(function (UploadedFile $image): void {
+            $today = now()->format('Y-m-d');
+
+            /** @var string $path */
+            $path = $image->store("images/{$today}", 'public');
+            $this->optimizeImage($path);
+
+            if ($path) {
+                session()->push('images', $path);
+
+                $this->dispatch(
+                    'image.uploaded',
+                    path: Storage::url($path),
+                    originalName: $image->getClientOriginalName()
+                );
+            } else { // @codeCoverageIgnoreStart
+                $this->addError('images', 'The image could not be uploaded.');
+                $this->dispatch('notification.created', message: 'The image could not be uploaded.');
+            } // @codeCoverageIgnoreEnd
+        });
+
+        $this->reset('images');
     }
 
     /**

--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -314,6 +314,10 @@ final class Create extends Component
      */
     private function deleteImage(string $path): void
     {
+        if (! str_starts_with($path, 'images/')) {
+            return;
+        }
+
         Storage::disk('public')->delete($path);
         $this->cleanSession($path);
     }

--- a/tests/Unit/Livewire/Questions/CreateTest.php
+++ b/tests/Unit/Livewire/Questions/CreateTest.php
@@ -410,7 +410,11 @@ test('updated method invokes handleUploads', function () {
     $component = Livewire::actingAs($user)->test(Create::class);
 
     $component->set('images', [$file]);
-    $component->invade()->updated('images');
+
+    $reflection = new ReflectionClass(Create::class);
+    $method = $reflection->getMethod('uploadImages');
+    $method->setAccessible(true);
+    $method->invoke($component->instance());
 
     expect(session('images'))->toBeArray()
         ->and(session('images'))->toContain($path);
@@ -431,7 +435,11 @@ test('unused image cleanup when store is called', function () {
         'toId' => $user->id,
     ]);
     $component->set('images', [$file]);
-    $component->call('uploadImages');
+
+    $reflection = new ReflectionClass(Create::class);
+    $method = $reflection->getMethod('uploadImages');
+    $method->setAccessible(true);
+    $method->invoke($component->instance());
 
     Storage::disk('public')->assertExists($path);
 
@@ -484,12 +492,15 @@ test('delete image', function () {
 
     Storage::disk('public')->assertExists($path);
 
-    $component->call('deleteImage', $path);
+    $reflection = new ReflectionClass(Create::class);
+    $method = $reflection->getMethod('deleteImage');
+    $method->setAccessible(true);
+    $method->invoke($component->instance(), $path);
 
     $pathAgain = $file->store('images', 'public');
     Storage::disk('public')->assertExists($pathAgain);
 
-    $component->call('deleteImage', $pathAgain);
+    $method->invoke($component->instance(), $pathAgain);
 
     Storage::disk('public')->assertMissing($pathAgain);
 });
@@ -598,7 +609,11 @@ test('non verified users can upload images', function () {
     ]);
 
     $component->set('images', [UploadedFile::fake()->image('test.jpg')]);
-    $component->call('uploadImages');
+
+    $reflection = new ReflectionClass(Create::class);
+    $method = $reflection->getMethod('uploadImages');
+    $method->setAccessible(true);
+    $method->invoke($component->instance());
 
     $component->assertHasNoErrors();
 });
@@ -613,7 +628,11 @@ test('company verified users can upload images', function () {
     ]);
 
     $component->set('images', [UploadedFile::fake()->image('test.jpg')]);
-    $component->call('uploadImages');
+
+    $reflection = new ReflectionClass(Create::class);
+    $method = $reflection->getMethod('uploadImages');
+    $method->setAccessible(true);
+    $method->invoke($component->instance());
 
     $component->assertHasNoErrors();
 });

--- a/tests/Unit/Livewire/Questions/CreateTest.php
+++ b/tests/Unit/Livewire/Questions/CreateTest.php
@@ -411,8 +411,7 @@ test('updated method invokes handleUploads', function () {
 
     $component->set('images', [$file]);
 
-    $reflection = new ReflectionClass(Create::class);
-    $method = $reflection->getMethod('uploadImages');
+    $method = new ReflectionMethod(Create::class, 'uploadImages');
     $method->setAccessible(true);
     $method->invoke($component->instance());
 
@@ -436,8 +435,7 @@ test('unused image cleanup when store is called', function () {
     ]);
     $component->set('images', [$file]);
 
-    $reflection = new ReflectionClass(Create::class);
-    $method = $reflection->getMethod('uploadImages');
+    $method = new ReflectionMethod(Create::class, 'uploadImages');
     $method->setAccessible(true);
     $method->invoke($component->instance());
 
@@ -492,8 +490,7 @@ test('delete image', function () {
 
     Storage::disk('public')->assertExists($path);
 
-    $reflection = new ReflectionClass(Create::class);
-    $method = $reflection->getMethod('deleteImage');
+    $method = new ReflectionMethod(Create::class, 'deleteImage');
     $method->setAccessible(true);
     $method->invoke($component->instance(), $path);
 
@@ -610,8 +607,7 @@ test('non verified users can upload images', function () {
 
     $component->set('images', [UploadedFile::fake()->image('test.jpg')]);
 
-    $reflection = new ReflectionClass(Create::class);
-    $method = $reflection->getMethod('uploadImages');
+    $method = new ReflectionMethod(Create::class, 'uploadImages');
     $method->setAccessible(true);
     $method->invoke($component->instance());
 
@@ -629,8 +625,7 @@ test('company verified users can upload images', function () {
 
     $component->set('images', [UploadedFile::fake()->image('test.jpg')]);
 
-    $reflection = new ReflectionClass(Create::class);
-    $method = $reflection->getMethod('uploadImages');
+    $method = new ReflectionMethod(Create::class, 'uploadImages');
     $method->setAccessible(true);
     $method->invoke($component->instance());
 


### PR DESCRIPTION
Addresses the security advisory [GHSA-gqq4-5mv7-ffv2](https://github.com/pinkary-project/pinkary.com/security/advisories/GHSA-gqq4-5mv7-ffv2).

This pull request refactors the `Create` class in `app/Livewire/Questions` by changing the visibility of the `uploadImages` and `deleteImage` methods from public to private.

Corresponding updates were made to the Create component unit test to use Reflection to change the visibility and invoke these methods as this is the only reason the methods were public.