### PR TITLE
Fix: Method visibility - optimizeImages

### DIFF
--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -266,7 +266,7 @@ final class Create extends Component
     /**
      * Optimize the images.
      */
-    public function optimizeImage(string $path): void
+    private function optimizeImage(string $path): void
     {
         $imagePath = Storage::disk('public')->path($path);
         $imagick = new Imagick($imagePath);

--- a/tests/Unit/Livewire/Questions/CreateTest.php
+++ b/tests/Unit/Livewire/Questions/CreateTest.php
@@ -513,7 +513,9 @@ test('optimizeImage method resizes and saves the image', function () {
         'toId' => $user->id,
     ]);
 
-    $component->call('optimizeImage', $path);
+    $method = new ReflectionMethod(Create::class, 'optimizeImage');
+    $method->setAccessible(true);
+    $method->invoke($component->instance(), $path);
 
     Storage::disk('public')->assertExists($path);
 
@@ -562,7 +564,9 @@ test('optimizeImage method resizes and saves image with multiple frames', functi
         'toId' => $user->id,
     ]);
 
-    $component->call('optimizeImage', $path);
+    $method = new ReflectionMethod(Create::class, 'optimizeImage');
+    $method->setAccessible(true);
+    $method->invoke($component->instance(), $path);
 
     Storage::disk('public')->assertExists($path);
 


### PR DESCRIPTION
As per discussion in #735 visibility on method `optimizeImages` changed to private to ensure no future vulnerability issues.