### PR TITLE
Fix: Client side delete images causes 500 error

### DIFF
--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -358,10 +358,7 @@ final class Create extends Component
      */
     private function cleanSession(string $path): void
     {
-        /** @var array<int, string> $images */
-        $images = session()->get('images', []);
-
-        $remainingImages = collect($images)
+        $remainingImages = collect($this->getSessionImages())
             ->reject(fn (string $imagePath): bool => $imagePath === $path);
 
         session()->put('images', $remainingImages->toArray());
@@ -372,13 +369,23 @@ final class Create extends Component
      */
     private function deleteUnusedImages(): void
     {
-        /** @var array<int, string> $images */
-        $images = session()->get('images', []);
-
-        collect($images)
+        collect($this->getSessionImages())
             ->reject(fn (string $path): bool => str_contains($this->content, $path))
             ->each(fn (string $path): ?bool => $this->deleteImage($path));
 
         session()->forget('images');
+    }
+
+    /**
+     * Get the session images.
+     *
+     * @return array<int, string>
+     */
+    private function getSessionImages(): array
+    {
+        /** @var array<int, string> $images */
+        $images = session()->get('images', []);
+
+        return $images;
     }
 }

--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -30,6 +30,8 @@ final class Create extends Component
 {
     use WithFileUploads;
 
+    private const string IMAGE_DISK = 'public';
+
     /**
      * Max number of images allowed.
      */
@@ -284,7 +286,7 @@ final class Create extends Component
      */
     private function optimizeImage(string $path): void
     {
-        $imagePath = Storage::disk('public')->path($path);
+        $imagePath = Storage::disk(self::IMAGE_DISK)->path($path);
         $imagick = new Imagick($imagePath);
 
         if ($imagick->getNumberImages() > 1) {
@@ -318,7 +320,7 @@ final class Create extends Component
             return;
         }
 
-        Storage::disk('public')->delete($path);
+        Storage::disk(self::IMAGE_DISK)->delete($path);
         $this->cleanSession($path);
     }
 
@@ -331,7 +333,7 @@ final class Create extends Component
             $today = now()->format('Y-m-d');
 
             /** @var string $path */
-            $path = $image->store("images/{$today}", 'public');
+            $path = $image->store("images/{$today}", self::IMAGE_DISK);
             $this->optimizeImage($path);
 
             if ($path) {

--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -282,6 +282,42 @@ final class Create extends Component
     }
 
     /**
+     * Validate and delete the image if it meets criteria.
+     */
+    public function deleteImageAfterValidation(string $path): void
+    {
+        if (! $this->validateImagePath($path)) {
+            return;
+        }
+
+        $this->deleteImage($path);
+    }
+
+    /**
+     * Validate if the image path is eligible for deletion.
+     */
+    private function validateImagePath(string $path): bool
+    {
+        $images = $this->getSessionImages();
+
+        return in_array($path, $images, true) && $this->isValidImageFile($path);
+    }
+
+    /**
+     * Check if the path exists and is a valid image file.
+     */
+    private function isValidImageFile(string $path): bool
+    {
+        if (! Storage::disk(self::IMAGE_DISK)->exists($path)) {
+            return false;
+        }
+
+        $imageContent = Storage::disk(self::IMAGE_DISK)->get($path) ?: '';
+
+        return @getimagesizefromstring($imageContent) !== false;
+    }
+
+    /**
      * Optimize the images.
      */
     private function optimizeImage(string $path): void

--- a/resources/js/image-upload.js
+++ b/resources/js/image-upload.js
@@ -138,7 +138,7 @@ const imageUpload = () => ({
 
     removeImage(event, index) {
         event.preventDefault();
-        this.$wire.deleteImage(
+        this.$wire.deleteImageAfterValidation(
             this.normalizePath(this.images[index].path)
         );
         this.removeMarkdownImage(index);


### PR DESCRIPTION
This PR addresses the 500 error caused by calling the deleteImages method from the Alpine component `upload-images.js`. It's visibility was changed due to concerns over security, so this has been addressed by add a new public delete method that includes validation that the image path is a file that exists in the location we have put it & that the file is indeed an image file.

### Enhancements to image handling:

* **Introduction of a constant for the image disk:**
  - Added `private const string IMAGE_DISK = 'public';` to centralize the disk configuration.

* **Image validation and deletion:**
  - Added `deleteImageAfterValidation` method to validate and delete images if they meet specific criteria.
  - Introduced `validateImagePath` and `isValidImageFile` methods to ensure that only valid image paths are processed.
  - Updated the `removeImage` method to call `deleteImageAfterValidation` instead of `deleteImage` for improved validation before deletion. 