### PR TITLE
Fix: Youtube Previews

### DIFF
--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -9,7 +9,6 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Exception\MalformedUriException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\HttpClientException;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -87,7 +86,6 @@ final readonly class MetaData
 
         return ! ($dimensions && ($dimensions[0] < $min_width || $dimensions[1] < $min_height));
     }
-
 
     /**
      * Get the meta-data for a given URL.

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -108,7 +108,6 @@ final readonly class MetaData
             }
         }
 
-
         $data = collect();
 
         try {

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -9,10 +9,12 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Exception\MalformedUriException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\HttpClientException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
+use Illuminate\Support\Uri;
 
 final readonly class MetaData
 {
@@ -86,6 +88,7 @@ final readonly class MetaData
         return ! ($dimensions && ($dimensions[0] < $min_width || $dimensions[1] < $min_height));
     }
 
+
     /**
      * Get the meta-data for a given URL.
      *
@@ -95,7 +98,11 @@ final readonly class MetaData
     {
         // If it’s a YouTube link, go straight to oEmbed
         // return early to bypass bot detection issues.
-        if (Str::contains($this->url, ['youtube.com', 'youtu.be'])) {
+        if (in_array(
+            needle: Uri::of($this->url)->host(),
+            haystack: ['youtube.com', 'www.youtube.com', 'youtu.be', 'www.youtu.be'],
+            strict: true
+        )) {
             $oembed = $this->fetchOEmbed(
                 service: 'https://www.youtube.com/oembed',
                 options: [

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -93,6 +93,22 @@ final readonly class MetaData
      */
     private function getData(): Collection
     {
+        // If it’s a YouTube link, go straight to oEmbed
+        // return early to bypass bot detection issues.
+        if (Str::contains($this->url, ['youtube.com', 'youtu.be'])) {
+            $oembed = $this->fetchOEmbed(
+                service: 'https://www.youtube.com/oembed',
+                options: [
+                    'maxwidth' => self::CARD_WIDTH,
+                    'maxheight' => self::CARD_HEIGHT,
+                ]
+            );
+            if ($oembed->isNotEmpty()) {
+                return $oembed;
+            }
+        }
+
+
         $data = collect();
 
         try {

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -235,27 +235,6 @@ final readonly class MetaData
             }
         }
 
-        if ($data->has('site_name') && $data->get('site_name') === 'YouTube') {
-            $youtube = $this->fetchOEmbed(
-                service: 'https://www.youtube.com/oembed',
-                options: [
-                    'maxwidth' => self::CARD_WIDTH,
-                    'maxheight' => self::CARD_HEIGHT,
-                ]);
-
-            if ($youtube->isNotEmpty()) {
-                foreach ($youtube as $key => $value) {
-                    $value = $key === 'html'
-                        ? $this->ensureCorrectSize((string) $value)
-                        : $value;
-
-                    if ($value !== '') {
-                        $data->put($key, $value);
-                    }
-                }
-            }
-        }
-
         return $data->unique();
     }
 }


### PR DESCRIPTION
After doing some research with @MrPunyapal, on the responses that the server was receiving when requesting YouTube urls, that the user has entered, we discovered it was being bot detected.

Rather than try to bypass with spoofing the User-Agent, this PR removes the initial request to YouTube by checking for the presence of youtube urls, and automatically returning the oEmbed data to display the preview.

YouTube has a really good url verification layer when they ingest the oEmbed request, so if someone tries to use a url like `https://sub.youtube.com.other.domain/watch?v=dQw4w9WgXcQ` - YouTube will still parse it and return valid oEmbed json response. As per screenshot:

<img width="567" alt="Screenshot 2025-01-10 at 10 08 38 PM" src="https://github.com/user-attachments/assets/cc4ad879-eaa3-4f95-987f-da44fb2f89b4" />

Just in case they are able to find a way around this, we will allow empty responses from the oEmbed request to fall through to the rest of the parsing logic where they will be handled appropriately, as per other malformed or incorrectly urls.