### PR TITLE
ci(tests): fix caching of PHP dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Cache Dependencies
+      - name: Cache Dependencies PHP
+        id: php-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
-          path: ~/.composer/cache/files
+          path: vendor
           key: dependencies-php-composer-${{ hashFiles('composer.lock') }}
 
       - name: Setup PHP
@@ -57,6 +58,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install PHP dependencies
+        if: steps.php-cache.outputs.cache-hit != 'true'
         run: composer install --no-interaction --no-progress --ansi
 
       - name: Get NPM cache directory


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pinkary team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR resolves an issue with caching PHP dependencies in CI.


**Before - cache error:**

<img width="986" alt="image" src="https://github.com/user-attachments/assets/77985387-23d4-4125-828b-394a286a46a4" />


**After - cache created:**

<img width="1254" alt="Screenshot 2025-01-19 at 10 32 34" src="https://github.com/user-attachments/assets/bed6ea15-cb1e-4354-a305-48d605190d3d" />


**Next run - cache restored and install skipped:**

<img width="1413" alt="Screenshot 2025-01-19 at 10 29 54" src="https://github.com/user-attachments/assets/dfc34de5-6d89-4b43-acd4-09f3967ecf8e" />