### PR TITLE
Chore: Running update to multibyte functions when running pint.

### DIFF
--- a/app/Services/Changelog.php
+++ b/app/Services/Changelog.php
@@ -27,14 +27,14 @@ final readonly class Changelog
         return collect($blocks)
             ->mapWithKeys(function (string $block): array {
                 /** @var string $block */
-                $lines = explode("\n", trim($block));
-                $version = trim(array_shift($lines));
+                $lines = explode("\n", mb_trim($block));
+                $version = mb_trim(array_shift($lines));
 
-                $publishedAt = trim(str_replace('>', '', (string) array_shift($lines)));
+                $publishedAt = mb_trim(str_replace('>', '', (string) array_shift($lines)));
                 array_shift($lines);
                 $changes = collect($lines)
                     ->filter(fn (string $line): bool => ! str_starts_with($line, '##'))
-                    ->map(fn (string $line): string => trim(str_replace('- ', '', $line)))
+                    ->map(fn (string $line): string => mb_trim(str_replace('- ', '', $line)))
                     ->all();
 
                 return [$version => ['publishedAt' => $publishedAt, 'changes' => $changes]];

--- a/app/Services/Git.php
+++ b/app/Services/Git.php
@@ -13,7 +13,7 @@ final readonly class Git
      */
     public function getLatestTag(): string
     {
-        return trim(
+        return mb_trim(
             Process::path(base_path())->run(['git', 'describe', '--tags', '--abbrev=0'])->output(),
         );
     }

--- a/app/Services/ParsableContentProviders/CodeProviderParsable.php
+++ b/app/Services/ParsableContentProviders/CodeProviderParsable.php
@@ -21,7 +21,7 @@ final readonly class CodeProviderParsable implements ParsableContentProvider
                 $code = $matches['code'];
                 $language = empty($matches['language'])
                     ? 'plaintext'
-                    : trim($matches['language']);
+                    : mb_trim($matches['language']);
 
                 $highlighter = new Highlighter();
 

--- a/config/sponsors.php
+++ b/config/sponsors.php
@@ -16,10 +16,10 @@ return [
     */
 
     'github_usernames' => collect(explode(',', type(env('SPONSORS_GITHUB_USERNAMES', ''))->asString()))->map(
-        fn (string $username): string => trim($username)
+        fn (string $username): string => mb_trim($username)
     )->filter()->values()->all(),
 
     'github_company_usernames' => collect(explode(',', type(env('SPONSORS_GITHUB_COMPANY_USERNAMES', ''))->asString()))->map(
-        fn (string $username): string => trim($username)
+        fn (string $username): string => mb_trim($username)
     )->filter()->values()->all(),
 ];


### PR DESCRIPTION
Pint now updates all uses of `trim()` to the multibyte versions.
This PR has just run Pint globally on the repo & committed the lint changes.