### PR TITLE
Update type hints in model docblocks to use $this instead of covariant $this

### DIFF
--- a/app/Models/Bookmark.php
+++ b/app/Models/Bookmark.php
@@ -27,7 +27,7 @@ final class Bookmark extends Model
     /**
      * The question that the bookmark belongs to.
      *
-     * @return BelongsTo<Question, covariant $this>
+     * @return BelongsTo<Question, $this>
      */
     public function question(): BelongsTo
     {
@@ -37,7 +37,7 @@ final class Bookmark extends Model
     /**
      * The user that the bookmark belongs to.
      *
-     * @return BelongsTo<User, covariant $this>
+     * @return BelongsTo<User, $this>
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Hashtag.php
+++ b/app/Models/Hashtag.php
@@ -37,7 +37,7 @@ final class Hashtag extends Model
     }
 
     /**
-     * @return BelongsToMany<Question, covariant $this>
+     * @return BelongsToMany<Question, $this>
      */
     public function questions(): BelongsToMany
     {

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -27,7 +27,7 @@ final class Like extends Model
     /**
      * The question that the like belongs to.
      *
-     * @return BelongsTo<Question, covariant $this>
+     * @return BelongsTo<Question, $this>
      */
     public function question(): BelongsTo
     {
@@ -37,7 +37,7 @@ final class Like extends Model
     /**
      * The user that the like belongs to.
      *
-     * @return BelongsTo<User, covariant $this>
+     * @return BelongsTo<User, $this>
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -28,7 +28,7 @@ final class Link extends Model
     /**
      * Get the user that owns the link.
      *
-     * @return BelongsTo<User, covariant $this>
+     * @return BelongsTo<User, $this>
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -144,7 +144,7 @@ final class Question extends Model implements Viewable
     /**
      * Get the user that the question was sent from.
      *
-     * @return BelongsTo<User, covariant $this>
+     * @return BelongsTo<User, $this>
      */
     public function from(): BelongsTo
     {
@@ -154,7 +154,7 @@ final class Question extends Model implements Viewable
     /**
      * Get the user that the question was sent to.
      *
-     * @return BelongsTo<User, covariant $this>
+     * @return BelongsTo<User, $this>
      */
     public function to(): BelongsTo
     {
@@ -164,7 +164,7 @@ final class Question extends Model implements Viewable
     /**
      * Get the bookmarks for the question.
      *
-     * @return HasMany<Bookmark, covariant $this>
+     * @return HasMany<Bookmark, $this>
      */
     public function bookmarks(): HasMany
     {
@@ -174,7 +174,7 @@ final class Question extends Model implements Viewable
     /**
      * Get the likes for the question.
      *
-     * @return HasMany<Like, covariant $this>
+     * @return HasMany<Like, $this>
      */
     public function likes(): HasMany
     {
@@ -212,7 +212,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return BelongsTo<Question, covariant $this>
+     * @return BelongsTo<Question, $this>
      */
     public function root(): BelongsTo
     {
@@ -222,7 +222,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return BelongsTo<Question, covariant $this>
+     * @return BelongsTo<Question, $this>
      */
     public function parent(): BelongsTo
     {
@@ -232,7 +232,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return HasMany<Question, covariant $this>
+     * @return HasMany<Question, $this>
      */
     public function children(): HasMany
     {
@@ -242,7 +242,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return HasMany<Question, covariant $this>
+     * @return HasMany<Question, $this>
      */
     public function descendants(): HasMany
     {
@@ -252,7 +252,7 @@ final class Question extends Model implements Viewable
     }
 
     /**
-     * @return BelongsToMany<Hashtag, covariant $this>
+     * @return BelongsToMany<Hashtag, $this>
      */
     public function hashtags(): BelongsToMany
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -100,7 +100,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's bookmarks.
      *
-     * @return HasMany<Bookmark, covariant $this>
+     * @return HasMany<Bookmark, $this>
      */
     public function bookmarks(): HasMany
     {
@@ -110,7 +110,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's links.
      *
-     * @return HasMany<Link, covariant $this>
+     * @return HasMany<Link, $this>
      */
     public function links(): HasMany
     {
@@ -120,7 +120,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's questions sent.
      *
-     * @return HasMany<Question, covariant $this>
+     * @return HasMany<Question, $this>
      */
     public function questionsSent(): HasMany
     {
@@ -130,7 +130,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's questions received.
      *
-     * @return HasMany<Question, covariant $this>
+     * @return HasMany<Question, $this>
      */
     public function questionsReceived(): HasMany
     {
@@ -138,7 +138,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     }
 
     /**
-     * @return HasOne<Question, covariant $this>
+     * @return HasOne<Question, $this>
      */
     public function pinnedQuestion(): HasOne
     {
@@ -149,7 +149,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's followers.
      *
-     * @return BelongsToMany<User, covariant $this>
+     * @return BelongsToMany<User, $this>
      */
     public function followers(): BelongsToMany
     {
@@ -159,7 +159,7 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     /**
      * Get the user's following.
      *
-     * @return BelongsToMany<User, covariant $this>
+     * @return BelongsToMany<User, $this>
      */
     public function following(): BelongsToMany
     {


### PR DESCRIPTION
Refine type hints in model docblocks for clarity and consistency by replacing 'covariant $this' with '$this'.

Referring to #718