### PR TITLE
Fix: like and bookmark buttons with back key

### DIFF
--- a/resources/js/bookmark-button.js
+++ b/resources/js/bookmark-button.js
@@ -1,16 +1,17 @@
 import { abbreviate } from "./abbreviate";
 
-const bookmarkButton = (id, isBookmarked, count, isAuthenticated) => ({
+const bookmarkButton = (id, isAuthenticated) => ({
     id,
-    isBookmarked,
-    count,
     isAuthenticated,
+    isBookmarked: false,
+    count: 0,
     bookmarkButtonTitle: '',
     bookmarkButtonText: '',
 
     init() {
-        this.setTitle();
-        this.setText();
+        this.isBookmarked = this.$el.dataset.isBookmarked === 'true';
+        this.count = parseInt(this.$el.dataset.bookmarksCount);
+        this.setAll();
         this.initEventListeners();
     },
 
@@ -47,8 +48,7 @@ const bookmarkButton = (id, isBookmarked, count, isAuthenticated) => ({
             if (event.detail.id == this.id) {
                 this.isBookmarked = true;
                 this.count++;
-                this.setTitle();
-                this.setText();
+                this.setAll();
             }
         });
 
@@ -56,10 +56,16 @@ const bookmarkButton = (id, isBookmarked, count, isAuthenticated) => ({
             if (event.detail.id == this.id) {
                 this.isBookmarked = false;
                 this.count--;
-                this.setTitle();
-                this.setText();
+                this.setAll();
             }
         });
+    },
+
+    setAll() {
+        this.$el.dataset.isBookmarked = this.isBookmarked;
+        this.$el.dataset.bookmarksCount = this.count;
+        this.setTitle();
+        this.setText();
     },
 
     animateBookmarkButton() {

--- a/resources/js/like-button.js
+++ b/resources/js/like-button.js
@@ -1,17 +1,18 @@
 import { abbreviate } from "./abbreviate";
 import { particlesEffect } from "./particles-effect";
 
-const likeButton = (id, isLiked, count, isAuthenticated) => ({
+const likeButton = (id, isAuthenticated) => ({
     id,
-    isLiked,
-    count,
     isAuthenticated,
+    isLiked: false,
+    count: 0,
     likeButtonTitle: '',
     likeButtonText: '',
 
     init() {
-        this.setTitle();
-        this.setText();
+        this.isLiked = this.$el.dataset.isLiked === 'true';
+        this.count = parseInt(this.$el.dataset.likesCount);
+        this.setAll();
         this.initEventListeners();
     },
 
@@ -24,8 +25,6 @@ const likeButton = (id, isLiked, count, isAuthenticated) => ({
     },
 
     toggleLike(e) {
-
-
         if (!this.isAuthenticated) {
             window.Livewire.navigate('/login');
             return;
@@ -46,8 +45,7 @@ const likeButton = (id, isLiked, count, isAuthenticated) => ({
             if (event.detail.id == this.id) {
                 this.isLiked = true;
                 this.count++;
-                this.setTitle();
-                this.setText();
+                this.setAll();
             }
         });
 
@@ -55,10 +53,16 @@ const likeButton = (id, isLiked, count, isAuthenticated) => ({
             if (event.detail.id == this.id) {
                 this.isLiked = false;
                 this.count--;
-                this.setTitle();
-                this.setText();
+                this.setAll();
             }
         });
+    },
+
+    setAll() {
+        this.$el.dataset.isLiked = this.isLiked;
+        this.$el.dataset.likesCount = this.count;
+        this.setTitle();
+        this.setText();
     }
 });
 

--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -213,8 +213,10 @@
                     @endphp
 
                     <button
-                        x-data="likeButton('{{ $question->id }}', @js($likeExists), {{ $likesCount }}, @js(auth()->check()))"
+                        x-data="likeButton('{{ $question->id }}', @js(auth()->check()))"
                         x-cloak
+                        data-is-liked="{{ $likeExists }}"
+                        data-likes-count="{{ $likesCount }}"
                         data-navigate-ignore="true"
                         x-on:click="toggleLike"
                         :title="likeButtonTitle"

--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -215,7 +215,7 @@
                     <button
                         x-data="likeButton('{{ $question->id }}', @js(auth()->check()))"
                         x-cloak
-                        data-is-liked="{{ $likeExists }}"
+                        data-is-liked="@js($likeExists)"
                         data-likes-count="{{ $likesCount }}"
                         data-navigate-ignore="true"
                         x-on:click="toggleLike"
@@ -273,7 +273,9 @@
 
                     <button
                         data-navigate-ignore="true"
-                        x-data="bookmarkButton('{{ $question->id }}', @js($question->is_bookmarked), {{ $question->bookmarks_count }}, @js(auth()->check()))"
+                        x-data="bookmarkButton('{{ $question->id }}', @js(auth()->check()))"
+                        data-is-bookmarked="@js($question->is_bookmarked)"
+                        data-bookmarks-count="{{ $question->bookmarks_count }}"
                         x-cloak
                         x-on:click="toggleBookmark"
                         :title="bookmarkButtonTitle"


### PR DESCRIPTION
When we like or bookmark any post and get into details and click on back button it lose the state and same happens with unlike or unbookmarked.

In this PR I have solved that issue.
