### PR TITLE
Add 'Calcutta' timezone alongside 'Kolkata' for better Intl compatibility

### DIFF
--- a/app/Rules/ValidTimezone.php
+++ b/app/Rules/ValidTimezone.php
@@ -354,6 +354,7 @@ final readonly class ValidTimezone implements ValidationRule
             'Asia/Tashkent' => 'Tashkent (UTC+05:00)',
             'Asia/Colombo' => 'Colombo (UTC+05:30)',
             'Asia/Kolkata' => 'Kolkata (UTC+05:30)',
+            'Asia/Calcutta' => 'Kolkata (UTC+05:30)',
             'Asia/Kathmandu' => 'Kathmandu (UTC+05:45)',
             'Asia/Almaty' => 'Almaty (UTC+06:00)',
             'Asia/Bishkek' => 'Bishkek (UTC+06:00)',


### PR DESCRIPTION
### What does this PR do?

This PR adds the timezone entry `'Calcutta'` alongside the existing `'Kolkata'` in the timezone array.

### Why is this change needed?

- The JavaScript `Intl.DateTimeFormat().resolvedOptions().timeZone` API returns `'Asia/Calcutta'` on some environments.
- The original timezone array only contains `'Kolkata'` but not `'Calcutta'`.
- Adding `'Calcutta'` ensures compatibility with environments or browsers returning `'Calcutta'`, preventing potential issues where the timezone is considered invalid or unrecognized.

### How was this tested?

- Verified locally by running `Intl.DateTimeFormat().resolvedOptions().timeZone` which returned `'Asia/Calcutta'`.
- Confirmed that the new entry `'Calcutta'` exists in the timezone array, allowing proper recognition.

### Additional notes

- No breaking changes.
- Both `'Kolkata'` and `'Calcutta'` now coexist to cover all cases.

---

If this PR looks good, please consider merging to improve timezone support.

Thanks!  
— Tushar Nain
