### PR TITLE
Remove xrho.com

### DIFF
--- a/app/Rules/UnauthorizedEmailProviders.php
+++ b/app/Rules/UnauthorizedEmailProviders.php
@@ -3646,7 +3646,6 @@ final readonly class UnauthorizedEmailProviders implements ValidationRule
             'xoxox.cc',
             'xperiae5.com',
             'xrap.de',
-            'xrho.com',
             'xvx.us',
             'xww.ro',
             'xxhamsterxx.ga',


### PR DESCRIPTION
Not a disposable email domain

```
;; QUESTION SECTION:
;xrho.com.                      IN      MX

;; ANSWER SECTION:
xrho.com.               300     IN      MX      39 route1.mx.cloudflare.net.
xrho.com.               300     IN      MX      72 route3.mx.cloudflare.net.
xrho.com.               300     IN      MX      54 route2.mx.cloudflare.net.
```