### PR TITLE
Fix: link previews on mobile

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -55,3 +55,7 @@ particleEffect {
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+#link-preview-card iframe {
+    width: 100%;
+}


### PR DESCRIPTION
## Before
<img width="509" height="408" alt="image" src="https://github.com/user-attachments/assets/79c2f5f5-b7f5-41d4-9849-e9daf00c085c" />

## After
<img width="568" height="421" alt="image" src="https://github.com/user-attachments/assets/be9e00d2-d9d1-4480-b10b-fc75eb524a1c" />

