### PR TITLE
Feat: schedule weekly Database VACUUM using db:vacuum command

### DIFF
--- a/app/Console/Commands/VacuumDatabaseCommand.php
+++ b/app/Console/Commands/VacuumDatabaseCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class VacuumDatabaseCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:vacuum';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Runs VACUUM command on the database.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        DB::statement('VACUUM');
+    }
+}

--- a/app/Console/Commands/VacuumDatabaseCommand.php
+++ b/app/Console/Commands/VacuumDatabaseCommand.php
@@ -26,7 +26,7 @@ final class VacuumDatabaseCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle(): void
     {
         DB::statement('VACUUM');
     }

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,6 +6,7 @@ use App\Console\Commands\DeleteNonEmailVerifiedUsersCommand;
 use App\Console\Commands\PerformDatabaseBackupCommand;
 use App\Console\Commands\SendUnreadNotificationEmailsCommand;
 use App\Console\Commands\SyncVerifiedUsersCommand;
+use App\Console\Commands\VacuumDatabaseCommand;
 use App\Jobs\CleanUnusedUploadedImages;
 use Illuminate\Support\Facades\Schedule;
 
@@ -14,4 +15,5 @@ Schedule::command(SendUnreadNotificationEmailsCommand::class, ['--weekly' => tru
 Schedule::command(PerformDatabaseBackupCommand::class)->everySixHours();
 Schedule::command(DeleteNonEmailVerifiedUsersCommand::class)->hourly();
 Schedule::command(SyncVerifiedUsersCommand::class)->daily();
+Schedule::command(VacuumDatabaseCommand::class)->weekly();
 Schedule::job(CleanUnusedUploadedImages::class)->hourly();

--- a/tests/Console/VacuumDatabaseCommandTest.php
+++ b/tests/Console/VacuumDatabaseCommandTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Console\Commands\VacuumDatabaseCommand;
+use Illuminate\Support\Facades\DB;
+
+test('vacuum database', function () {
+    DB::shouldReceive('statement')
+        ->once()
+        ->with('VACUUM')
+        ->andReturnTrue();
+
+    $this->artisan(VacuumDatabaseCommand::class)
+        ->assertExitCode(0);
+});


### PR DESCRIPTION
### Description

Adds a new `db:vacuum` Artisan command to run the database `VACUUM` statement. The command is scheduled to run every 7 days.

### Changes

- New `VacuumDatabaseCommand` created
- Scheduled the command to run weekly
- Added test to validate the command execution

### Related Issue
https://github.com/pinkary-project/pinkary.com/issues/668