### PR TITLE
fix: correct argument format for weekly notifications

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -10,7 +10,7 @@ use App\Jobs\CleanUnusedUploadedImages;
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command(SendUnreadNotificationEmailsCommand::class)->dailyAt('13:00');
-Schedule::command(SendUnreadNotificationEmailsCommand::class, ['--weekly' => true])->weekly()->mondays()->at('13:00');
+Schedule::command(SendUnreadNotificationEmailsCommand::class, ['--weekly'])->weekly()->mondays()->at('13:00');
 Schedule::command(PerformDatabaseBackupCommand::class)->everySixHours();
 Schedule::command(DeleteNonEmailVerifiedUsersCommand::class)->hourly();
 Schedule::command(SyncVerifiedUsersCommand::class)->daily();


### PR DESCRIPTION
We faced this after updating it to Laravel 12.
<img width="1525" height="66" alt="image" src="https://github.com/user-attachments/assets/7f114b7b-7c63-4bbd-86ff-0c3a5c6cb7aa" />
