### PR TITLE
Feat: people to follow v2

### DIFF
--- a/app/Livewire/Home/Users.php
+++ b/app/Livewire/Home/Users.php
@@ -105,7 +105,7 @@ final class Users extends Component
             ->whereHas('links', function (Builder $query): void {
                 $query->where('url', 'like', '%twitter.com%')
                     ->orWhere('url', 'like', '%github.com%')
-                    ->orWhere('url', 'like', '://x.com%');
+                    ->orWhere('url', 'like', '%://x.com%');
             })
             ->whereNotIn('id', $except->pluck('id'))
             ->withCount(['questionsReceived as answered_questions_count' => function (Builder $query): void {

--- a/app/Livewire/PeopleToFollow.php
+++ b/app/Livewire/PeopleToFollow.php
@@ -5,45 +5,45 @@ declare(strict_types=1);
 namespace App\Livewire;
 
 use App\Models\User;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Cache;
+use App\Services\PeopleToFollowRecommendations;
 use Illuminate\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 final class PeopleToFollow extends Component
 {
     /**
+     * The current page context for the widget.
+     */
+    #[Locked]
+    public string $context = 'generic';
+
+    /**
+     * The contextual user ID.
+     */
+    #[Locked]
+    public ?int $contextUserId = null;
+
+    /**
+     * The contextual question ID.
+     */
+    #[Locked]
+    public ?string $contextQuestionId = null;
+
+    /**
      * Render the component.
      */
-    public function render(): View
+    public function render(PeopleToFollowRecommendations $recommendations): View
     {
-        $authenticatedUserId = auth()->id();
-
-        $famousUsers = Cache::remember('top-50-users', now()->endOfDay(), fn (): array => User::query()
-            ->whereHas('links', function (Builder $query): void {
-                $query->where('url', 'like', '%twitter.com%')
-                    ->orWhere('url', 'like', '%github.com%')
-                    ->orWhere('url', 'like', '://x.com%');
-            })
-            ->withCount(['questionsReceived as answered_questions_count' => function (Builder $query): void {
-                $query->whereNotNull('answer');
-            }])
-            ->orderBy('answered_questions_count', 'desc')
-            ->limit(50)->pluck('id')->toArray()
-        );
+        $authenticatedUser = auth()->user();
 
         return view('livewire.people-to-follow', [
-            'users' => User::query()
-                ->whereIn('id', $famousUsers)
-                ->when($authenticatedUserId !== null, function (Builder $query) use ($authenticatedUserId): void {
-                    $query->where('id', '!=', $authenticatedUserId)
-                        ->whereDoesntHave('followers', function (Builder $query) use ($authenticatedUserId): void {
-                            $query->whereKey($authenticatedUserId);
-                        });
-                })
-                ->inRandomOrder()
-                ->limit(5)
-                ->get(),
+            'users' => $recommendations->forContext(
+                authenticatedUserId: $authenticatedUser instanceof User ? $authenticatedUser->id : null,
+                context: $this->context,
+                contextUserId: $this->contextUserId,
+                contextQuestionId: $this->contextQuestionId,
+            ),
         ]);
     }
 }

--- a/app/Livewire/PeopleToFollow.php
+++ b/app/Livewire/PeopleToFollow.php
@@ -17,6 +17,8 @@ final class PeopleToFollow extends Component
      */
     public function render(): View
     {
+        $authenticatedUserId = auth()->id();
+
         $famousUsers = Cache::remember('top-50-users', now()->endOfDay(), fn (): array => User::query()
             ->whereHas('links', function (Builder $query): void {
                 $query->where('url', 'like', '%twitter.com%')
@@ -33,6 +35,12 @@ final class PeopleToFollow extends Component
         return view('livewire.people-to-follow', [
             'users' => User::query()
                 ->whereIn('id', $famousUsers)
+                ->when($authenticatedUserId !== null, function (Builder $query) use ($authenticatedUserId): void {
+                    $query->where('id', '!=', $authenticatedUserId)
+                        ->whereDoesntHave('followers', function (Builder $query) use ($authenticatedUserId): void {
+                            $query->whereKey($authenticatedUserId);
+                        });
+                })
                 ->inRandomOrder()
                 ->limit(5)
                 ->get(),

--- a/app/Services/PeopleToFollowRecommendations.php
+++ b/app/Services/PeopleToFollowRecommendations.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 final readonly class PeopleToFollowRecommendations
 {
@@ -19,6 +20,8 @@ final readonly class PeopleToFollowRecommendations
     private const int FAMOUS_LIMIT = 50;
 
     private const int EXTENDED_FAMOUS_LIMIT = 200;
+
+    private const int THREAD_DEPTH_CAP = 20;
 
     /**
      * @return EloquentCollection<int, User>
@@ -57,7 +60,21 @@ final readonly class PeopleToFollowRecommendations
             ];
         }
 
-        return $this->usersForIds(array_slice($selectedIds, 0, $limit));
+        $users = $this->usersForIds(array_slice($selectedIds, 0, $limit));
+
+        if ($users->count() < $limit) {
+            $topUpIds = $this->genericFallbackUserIds(
+                authenticatedUserId: $authenticatedUserId,
+                excludeIds: $selectedIds,
+                limit: $limit - $users->count(),
+            );
+
+            if ($topUpIds !== []) {
+                $users = $users->merge($this->usersForIds($topUpIds));
+            }
+        }
+
+        return $users;
     }
 
     /**
@@ -75,18 +92,23 @@ final readonly class PeopleToFollowRecommendations
 
         $selectedIds = $this->availableUserIds([$question->to_id], $authenticatedUserId, [], 1);
 
+        // Load the full ancestor chain in a single recursive CTE (depth-capped at THREAD_DEPTH_CAP).
+        $threadRows = DB::select(
+            'WITH RECURSIVE thread (id, from_id, to_id, parent_id, depth) AS (
+                SELECT id, from_id, to_id, parent_id, 0 FROM questions WHERE id = ?
+                UNION ALL
+                SELECT q.id, q.from_id, q.to_id, q.parent_id, t.depth + 1
+                FROM questions q INNER JOIN thread t ON q.id = t.parent_id
+                WHERE t.depth < ?
+            )
+            SELECT from_id, to_id FROM thread',
+            [$questionId, self::THREAD_DEPTH_CAP]
+        );
+
         $threadParticipantIds = [];
-        $threadQuestion = $question;
-
-        while ($threadQuestion !== null) {
-            $threadParticipantIds[] = $threadQuestion->from_id;
-            $threadParticipantIds[] = $threadQuestion->to_id;
-
-            $threadQuestion = $threadQuestion->parent_id === null
-                ? null
-                : Question::query()
-                    ->select('id', 'from_id', 'to_id', 'parent_id')
-                    ->find($threadQuestion->parent_id);
+        foreach ($threadRows as $row) {
+            $threadParticipantIds[] = (int) $row->from_id;
+            $threadParticipantIds[] = (int) $row->to_id;
         }
 
         if (count($selectedIds) < $limit) {

--- a/app/Services/PeopleToFollowRecommendations.php
+++ b/app/Services/PeopleToFollowRecommendations.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Question;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Facades\Cache;
+
+final readonly class PeopleToFollowRecommendations
+{
+    private const int DEFAULT_LIMIT = 5;
+
+    private const int VERIFIED_LIMIT = 2;
+
+    private const int FAMOUS_LIMIT = 50;
+
+    private const int EXTENDED_FAMOUS_LIMIT = 200;
+
+    /**
+     * @return EloquentCollection<int, User>
+     */
+    public function forContext(
+        ?int $authenticatedUserId,
+        string $context = 'generic',
+        ?int $contextUserId = null,
+        ?string $contextQuestionId = null,
+        int $limit = self::DEFAULT_LIMIT,
+    ): EloquentCollection {
+        /** @var array<int, int> $selectedIds */
+        $selectedIds = match ($context) {
+            'profile' => $contextUserId === null
+                ? []
+                : $this->latestInteractedUserIds(
+                    userId: $contextUserId,
+                    authenticatedUserId: $authenticatedUserId,
+                    excludeIds: [$contextUserId],
+                    limit: $limit,
+                ),
+            'question' => $contextQuestionId === null
+                ? []
+                : $this->questionContextUserIds($contextQuestionId, $authenticatedUserId, $limit),
+            default => [],
+        };
+
+        if (count($selectedIds) < $limit) {
+            $selectedIds = [
+                ...$selectedIds,
+                ...$this->genericFallbackUserIds(
+                    authenticatedUserId: $authenticatedUserId,
+                    excludeIds: $selectedIds,
+                    limit: $limit - count($selectedIds),
+                ),
+            ];
+        }
+
+        return $this->usersForIds(array_slice($selectedIds, 0, $limit));
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function questionContextUserIds(string $questionId, ?int $authenticatedUserId, int $limit): array
+    {
+        $question = Question::query()
+            ->select('id', 'from_id', 'to_id', 'parent_id')
+            ->find($questionId);
+
+        if ($question === null) {
+            return [];
+        }
+
+        $selectedIds = $this->availableUserIds([$question->to_id], $authenticatedUserId, [], 1);
+
+        $threadParticipantIds = [];
+        $threadQuestion = $question;
+
+        while ($threadQuestion !== null) {
+            $threadParticipantIds[] = $threadQuestion->from_id;
+            $threadParticipantIds[] = $threadQuestion->to_id;
+
+            $threadQuestion = $threadQuestion->parent_id === null
+                ? null
+                : Question::query()
+                    ->select('id', 'from_id', 'to_id', 'parent_id')
+                    ->find($threadQuestion->parent_id);
+        }
+
+        if (count($selectedIds) < $limit) {
+            $selectedIds = [
+                ...$selectedIds,
+                ...$this->availableUserIds(
+                    userIds: $threadParticipantIds,
+                    authenticatedUserId: $authenticatedUserId,
+                    excludeIds: $selectedIds,
+                    limit: $limit - count($selectedIds),
+                ),
+            ];
+        }
+
+        if (count($selectedIds) < $limit) {
+            $selectedIds = [
+                ...$selectedIds,
+                ...$this->latestInteractedUserIds(
+                    userId: $question->to_id,
+                    authenticatedUserId: $authenticatedUserId,
+                    excludeIds: $selectedIds,
+                    limit: $limit - count($selectedIds),
+                ),
+            ];
+        }
+
+        return array_slice($selectedIds, 0, $limit);
+    }
+
+    /**
+     * @param  array<int, int>  $excludeIds
+     * @return array<int, int>
+     */
+    private function latestInteractedUserIds(
+        int $userId,
+        ?int $authenticatedUserId,
+        array $excludeIds,
+        int $limit,
+    ): array {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        $counterpartExpression = 'CASE WHEN from_id = ? THEN to_id ELSE from_id END';
+
+        /** @var array<int, int> $candidateIds */
+        $candidateIds = Question::query()
+            ->selectRaw("{$counterpartExpression} as counterpart_id, MAX(updated_at) as latest_interaction_at", [$userId])
+            ->where(function (Builder $query) use ($userId): void {
+                $query->where('from_id', $userId)
+                    ->orWhere('to_id', $userId);
+            })
+            ->whereNotNull('answer')
+            ->where('is_ignored', false)
+            ->where('is_reported', false)
+            ->groupByRaw($counterpartExpression, [$userId])
+            ->orderByDesc('latest_interaction_at')
+            ->limit(max(self::FAMOUS_LIMIT, $limit * 5))
+            ->pluck('counterpart_id')
+            ->all();
+
+        return $this->availableUserIds(
+            userIds: $candidateIds,
+            authenticatedUserId: $authenticatedUserId,
+            excludeIds: array_values(array_unique([...$excludeIds, $userId])),
+            limit: $limit,
+        );
+    }
+
+    /**
+     * @param  array<int, int>  $excludeIds
+     * @return array<int, int>
+     */
+    private function genericFallbackUserIds(?int $authenticatedUserId, array $excludeIds, int $limit): array
+    {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        $selectedIds = $this->verifiedUserIds(
+            authenticatedUserId: $authenticatedUserId,
+            excludeIds: $excludeIds,
+            limit: min(self::VERIFIED_LIMIT, $limit),
+        );
+
+        if (count($selectedIds) < $limit) {
+            $selectedIds = [
+                ...$selectedIds,
+                ...$this->famousUserIds(
+                    authenticatedUserId: $authenticatedUserId,
+                    excludeIds: [...$excludeIds, ...$selectedIds],
+                    limit: $limit - count($selectedIds),
+                    poolLimit: self::FAMOUS_LIMIT,
+                ),
+            ];
+        }
+
+        if (count($selectedIds) < $limit) {
+            $selectedIds = [
+                ...$selectedIds,
+                ...$this->famousUserIds(
+                    authenticatedUserId: $authenticatedUserId,
+                    excludeIds: [...$excludeIds, ...$selectedIds],
+                    limit: $limit - count($selectedIds),
+                    poolLimit: self::EXTENDED_FAMOUS_LIMIT,
+                ),
+            ];
+        }
+
+        return array_slice($selectedIds, 0, $limit);
+    }
+
+    /**
+     * @param  array<int, int>  $excludeIds
+     * @return array<int, int>
+     */
+    private function verifiedUserIds(?int $authenticatedUserId, array $excludeIds, int $limit): array
+    {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        /** @var array<int, int> $verifiedUserIds */
+        $verifiedUserIds = $this->availableUsersQuery($authenticatedUserId, $excludeIds)
+            ->whereHas('links', function (Builder $query): void {
+                $query->where('url', 'like', '%twitter.com%')
+                    ->orWhere('url', 'like', '%github.com%')
+                    ->orWhere('url', 'like', '%://x.com%');
+            })
+            ->where(function (Builder $query): void {
+                $query->where('is_verified', true)
+                    ->orWhereIn('username', array_merge(
+                        config()->array('sponsors.github_company_usernames', []),
+                        config()->array('sponsors.github_usernames', [])
+                    ));
+            })
+            ->inRandomOrder()
+            ->limit($limit)
+            ->pluck('id')
+            ->all();
+
+        return array_values($verifiedUserIds);
+    }
+
+    /**
+     * @param  array<int, int>  $excludeIds
+     * @return array<int, int>
+     */
+    private function famousUserIds(
+        ?int $authenticatedUserId,
+        array $excludeIds,
+        int $limit,
+        int $poolLimit,
+    ): array {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        /** @var array<int, int> $famousUsers */
+        $famousUsers = Cache::remember(
+            "top-{$poolLimit}-users",
+            now()->endOfDay(),
+            fn (): array => $this->famousUsersQuery()->limit($poolLimit)->pluck('id')->all()
+        );
+
+        $famousUsers = collect($famousUsers)
+            ->sortBy(static fn (): int => random_int(PHP_INT_MIN, PHP_INT_MAX))
+            ->values()
+            ->all();
+
+        return $this->availableUserIds(
+            userIds: $famousUsers,
+            authenticatedUserId: $authenticatedUserId,
+            excludeIds: $excludeIds,
+            limit: $limit,
+        );
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    private function famousUsersQuery(): Builder
+    {
+        return User::query()
+            ->whereHas('links', function (Builder $query): void {
+                $query->where('url', 'like', '%twitter.com%')
+                    ->orWhere('url', 'like', '%github.com%')
+                    ->orWhere('url', 'like', '%://x.com%');
+            })
+            ->withCount(['questionsReceived as answered_questions_count' => function (Builder $query): void {
+                $query->whereNotNull('answer');
+            }])
+            ->orderByDesc('answered_questions_count');
+    }
+
+    /**
+     * @param  array<int, int>  $userIds
+     * @return EloquentCollection<int, User>
+     */
+    private function usersForIds(array $userIds): EloquentCollection
+    {
+        if ($userIds === []) {
+            return new EloquentCollection();
+        }
+
+        /** @var EloquentCollection<int, User> $users */
+        $users = User::query()
+            ->whereIn('id', $userIds)
+            ->get()
+            ->keyBy('id');
+
+        return new EloquentCollection(
+            array_values(array_filter(
+                array_map(static fn (int $userId): ?User => $users->get($userId), $userIds),
+                static fn (?User $user): bool => $user instanceof User,
+            ))
+        );
+    }
+
+    /**
+     * @param  array<int, int>  $userIds
+     * @param  array<int, int>  $excludeIds
+     * @return array<int, int>
+     */
+    private function availableUserIds(
+        array $userIds,
+        ?int $authenticatedUserId,
+        array $excludeIds,
+        int $limit,
+    ): array {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        $orderedUserIds = array_values(array_unique(array_filter(
+            $userIds,
+            static fn (int $userId): bool => $userId > 0,
+        )));
+
+        if ($orderedUserIds === []) {
+            return [];
+        }
+
+        /** @var array<int, int> $availableIds */
+        $availableIds = $this->availableUsersQuery($authenticatedUserId, $excludeIds)
+            ->whereIn('id', $orderedUserIds)
+            ->pluck('id')
+            ->all();
+
+        $availableLookup = array_flip($availableIds);
+
+        return array_slice(array_filter(
+            $orderedUserIds,
+            static fn (int $userId): bool => array_key_exists($userId, $availableLookup),
+        ), 0, $limit);
+    }
+
+    /**
+     * @param  array<int, int>  $excludeIds
+     * @return Builder<User>
+     */
+    private function availableUsersQuery(?int $authenticatedUserId, array $excludeIds): Builder
+    {
+        return User::query()
+            ->when($excludeIds !== [], function (Builder $query) use ($excludeIds): void {
+                $query->whereNotIn('id', array_values(array_unique($excludeIds)));
+            })
+            ->when($authenticatedUserId !== null, function (Builder $query) use ($authenticatedUserId): void {
+                $query->where('id', '!=', $authenticatedUserId)
+                    ->whereDoesntHave('followers', function (Builder $query) use ($authenticatedUserId): void {
+                        $query->whereKey($authenticatedUserId);
+                    });
+            });
+    }
+}

--- a/app/View/Components/AppLayout.php
+++ b/app/View/Components/AppLayout.php
@@ -10,6 +10,15 @@ use Illuminate\View\View;
 final class AppLayout extends Component
 {
     /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        public string $peopleToFollowContext = 'generic',
+        public ?int $peopleToFollowUserId = null,
+        public ?string $peopleToFollowQuestionId = null,
+    ) {}
+
+    /**
      * Get the view / contents that represents the component.
      */
     public function render(): View

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -113,7 +113,11 @@
                 @if ($showRightRail)
                     <aside class="hidden lg:col-start-3 lg:block lg:pl-4 {{ $showDiscoverLayout ? 'lg:pt-[57px]' : 'lg:pt-4' }}">
                         <div class="lg:sticky lg:top-4">
-                            <livewire:people-to-follow />
+                            <livewire:people-to-follow
+                                :context="$peopleToFollowContext"
+                                :contextUserId="$peopleToFollowUserId"
+                                :contextQuestionId="$peopleToFollowQuestionId"
+                            />
                         </div>
                     </aside>
                 @endif

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout people-to-follow-context="profile" :people-to-follow-user-id="$user->id">
     <div class="space-y-0 border-x border-slate-200 py-0 dark:border-slate-700/50">
         <section class="border-b border-slate-200 bg-white/80 p-4 dark:border-slate-700/50 dark:bg-[#07101f]/95 sm:p-5">
             <livewire:links.index :userId="$user->id" />

--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -1,4 +1,8 @@
-<x-app-layout>
+<x-app-layout
+    people-to-follow-context="question"
+    :people-to-follow-user-id="$question->to_id"
+    :people-to-follow-question-id="$question->id"
+>
     <div class="py-0"
          x-data
          x-init="document.getElementById('q-{{ $question->id }}').scrollIntoView();">

--- a/tests/Http/Profile/Show/Questions/ShowTest.php
+++ b/tests/Http/Profile/Show/Questions/ShowTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Livewire\PeopleToFollow;
 use App\Livewire\Questions\Create;
 use App\Livewire\Questions\Show;
 use App\Models\Question;
@@ -140,4 +141,32 @@ test('it shows the parent questions', function () {
                 && $parentQuestions[1]->id === $parent2->id
                 && $parentQuestions[2]->id === $parent1->id;
         });
+});
+
+test('it shows question-context suggestions in the people to follow rail', function () {
+    $postUser = User::factory()->create();
+    $currentParticipant = User::factory()->create();
+    $recentInteractionUser = User::factory()->create(['name' => 'Question Rail Interaction']);
+
+    Question::factory()->create([
+        'from_id' => $recentInteractionUser->id,
+        'to_id' => $postUser->id,
+        'answer' => 'Question answer',
+        'updated_at' => now()->subMinutes(5),
+    ]);
+
+    $question = Question::factory()->create([
+        'from_id' => $currentParticipant->id,
+        'to_id' => $postUser->id,
+        'updated_at' => now(),
+    ]);
+
+    $response = $this->get(route('questions.show', [
+        'username' => $postUser->username,
+        'question' => $question->id,
+    ]));
+
+    $response->assertOk()
+        ->assertSeeLivewire(PeopleToFollow::class)
+        ->assertSee('Question Rail Interaction');
 });

--- a/tests/Http/Profile/ShowTest.php
+++ b/tests/Http/Profile/ShowTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Jobs\IncrementViews;
+use App\Livewire\PeopleToFollow;
+use App\Models\Question;
 use App\Models\User;
 
 beforeEach(function () {
@@ -37,4 +39,21 @@ it('does increment views', function () {
 
     $response->assertSee($this->user->name);
     Queue::assertPushed(IncrementViews::class);
+});
+
+it('shows recent interacted users in the people to follow rail', function () {
+    $interactedUser = User::factory()->create(['name' => 'Profile Rail Interaction']);
+
+    Question::factory()->create([
+        'from_id' => $interactedUser->id,
+        'to_id' => $this->user->id,
+        'answer' => 'Profile answer',
+        'updated_at' => now(),
+    ]);
+
+    $response = $this->get(route('profile.show', ['username' => $this->user->username]));
+
+    $response->assertOk()
+        ->assertSeeLivewire(PeopleToFollow::class)
+        ->assertSee('Profile Rail Interaction');
 });

--- a/tests/Unit/Livewire/PeopleToFollowTest.php
+++ b/tests/Unit/Livewire/PeopleToFollowTest.php
@@ -7,7 +7,11 @@ use App\Models\User;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Livewire;
 
-test('it renders the people to follow list', function () {
+beforeEach(function () {
+    Cache::forget('top-50-users');
+});
+
+it('renders the people to follow list', function () {
     User::factory(50)
         ->hasLinks(1, function (array $attributes, User $user): array {
             return ['url' => "https://twitter.com/{$user->username}"];
@@ -30,15 +34,35 @@ test('it renders the people to follow list', function () {
     expect($component->viewData('users'))->toHaveCount(5);
 });
 
-test('it caches the top 50 users', function () {
-    User::factory(50)
+it('excludes users already followed by the authenticated user', function () {
+    $user = User::factory()->create();
+
+    $discoveryPool = User::factory(50)
         ->hasLinks(1, function (array $attributes, User $user): array {
             return ['url' => "https://twitter.com/{$user->username}"];
         })
         ->hasQuestionsReceived(2, ['answer' => 'answer'])
         ->create();
 
-    Cache::forget('top-50-users');
+    $followedUser = $discoveryPool->first();
+
+    $user->following()->attach($followedUser);
+
+    $component = Livewire::actingAs($user)->test(PeopleToFollow::class);
+
+    expect($component->viewData('users')->contains(fn (User $suggestedUser): bool => $suggestedUser->is($followedUser)))
+        ->toBeFalse()
+        ->and($component->viewData('users'))
+        ->toHaveCount(5);
+});
+
+it('caches the top 50 users', function () {
+    User::factory(50)
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create();
 
     Livewire::test(PeopleToFollow::class);
 

--- a/tests/Unit/Livewire/PeopleToFollowTest.php
+++ b/tests/Unit/Livewire/PeopleToFollowTest.php
@@ -3,68 +3,51 @@
 declare(strict_types=1);
 
 use App\Livewire\PeopleToFollow;
+use App\Models\Question;
 use App\Models\User;
-use Illuminate\Support\Facades\Cache;
 use Livewire\Livewire;
 
-beforeEach(function () {
-    Cache::forget('top-50-users');
-});
-
-it('renders the people to follow list', function () {
-    User::factory(50)
+it('renders the people to follow widget', function () {
+    User::factory(5)
         ->hasLinks(1, function (array $attributes, User $user): array {
             return ['url' => "https://twitter.com/{$user->username}"];
         })
         ->hasQuestionsReceived(2, ['answer' => 'answer'])
         ->create();
 
-    $outsideDiscoveryPool = User::factory()
-        ->hasLinks(1, function (array $attributes, User $user): array {
-            return ['url' => "https://twitter.com/{$user->username}"];
-        })
-        ->hasQuestionsReceived(1, ['answer' => 'answer'])
-        ->create(['name' => 'Outside Discovery Pool']);
-
-    $component = Livewire::test(PeopleToFollow::class);
-
-    $component->assertSee('People to follow')
-        ->assertDontSee($outsideDiscoveryPool->name);
-
-    expect($component->viewData('users'))->toHaveCount(5);
+    Livewire::test(PeopleToFollow::class)
+        ->assertStatus(200)
+        ->assertSee('People to follow')
+        ->assertSee('View all');
 });
 
-it('excludes users already followed by the authenticated user', function () {
-    $user = User::factory()->create();
+it('uses the current context and authenticated user when rendering recommendations', function () {
+    $viewer = User::factory()->create();
+    $profileUser = User::factory()->create();
+    $followedInteractedUser = User::factory()->create();
+    $visibleInteractedUser = User::factory()->create();
 
-    $discoveryPool = User::factory(50)
-        ->hasLinks(1, function (array $attributes, User $user): array {
-            return ['url' => "https://twitter.com/{$user->username}"];
-        })
-        ->hasQuestionsReceived(2, ['answer' => 'answer'])
-        ->create();
+    $viewer->following()->attach($followedInteractedUser);
 
-    $followedUser = $discoveryPool->first();
+    Question::factory()->create([
+        'from_id' => $followedInteractedUser->id,
+        'to_id' => $profileUser->id,
+        'answer' => 'Followed answer',
+        'updated_at' => now()->subMinutes(2),
+    ]);
 
-    $user->following()->attach($followedUser);
+    Question::factory()->create([
+        'from_id' => $visibleInteractedUser->id,
+        'to_id' => $profileUser->id,
+        'answer' => 'Visible answer',
+        'updated_at' => now()->subMinute(),
+    ]);
 
-    $component = Livewire::actingAs($user)->test(PeopleToFollow::class);
-
-    expect($component->viewData('users')->contains(fn (User $suggestedUser): bool => $suggestedUser->is($followedUser)))
-        ->toBeFalse()
-        ->and($component->viewData('users'))
-        ->toHaveCount(5);
-});
-
-it('caches the top 50 users', function () {
-    User::factory(50)
-        ->hasLinks(1, function (array $attributes, User $user): array {
-            return ['url' => "https://twitter.com/{$user->username}"];
-        })
-        ->hasQuestionsReceived(2, ['answer' => 'answer'])
-        ->create();
-
-    Livewire::test(PeopleToFollow::class);
-
-    expect(Cache::has('top-50-users'))->toBeTrue();
+    Livewire::actingAs($viewer)->test(PeopleToFollow::class, [
+        'context' => 'profile',
+        'contextUserId' => $profileUser->id,
+    ])
+        ->assertStatus(200)
+        ->assertSee($visibleInteractedUser->name)
+        ->assertDontSee($followedInteractedUser->name);
 });

--- a/tests/Unit/Services/PeopleToFollowRecommendationsTest.php
+++ b/tests/Unit/Services/PeopleToFollowRecommendationsTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Question;
+use App\Models\User;
+use App\Services\PeopleToFollowRecommendations;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    Cache::forget('top-50-users');
+    Cache::forget('top-200-users');
+});
+
+it('returns generic fallback users from the discovery pool', function () {
+    User::factory(50)
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create();
+
+    $outsideDiscoveryPool = User::factory()
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(1, ['answer' => 'answer'])
+        ->create(['name' => 'Outside Discovery Pool']);
+
+    $users = (new PeopleToFollowRecommendations())->forContext(authenticatedUserId: null);
+
+    expect($users)
+        ->toHaveCount(5)
+        ->and($users->contains(fn (User $user): bool => $user->is($outsideDiscoveryPool)))
+        ->toBeFalse();
+});
+
+it('excludes users already followed by the authenticated user', function () {
+    $user = User::factory()->create();
+
+    $discoveryPool = User::factory(50)
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create();
+
+    $followedUser = $discoveryPool->first();
+
+    $user->following()->attach($followedUser);
+
+    $users = (new PeopleToFollowRecommendations())->forContext(authenticatedUserId: $user->id);
+
+    expect($users->contains(fn (User $suggestedUser): bool => $suggestedUser->is($followedUser)))
+        ->toBeFalse()
+        ->and($users)
+        ->toHaveCount(5);
+});
+
+it('shows the latest interacted users on profile pages before fallback users', function () {
+    $profileUser = User::factory()->create();
+
+    $interactedUsers = User::factory(6)->create();
+
+    $interactedUsers->each(function (User $interactedUser, int $index) use ($profileUser): void {
+        Question::factory()->create([
+            'from_id' => $interactedUser->id,
+            'to_id' => $profileUser->id,
+            'answer' => "Answer {$index}",
+            'updated_at' => now()->subMinutes($index),
+        ]);
+    });
+
+    $users = (new PeopleToFollowRecommendations())->forContext(
+        authenticatedUserId: null,
+        context: 'profile',
+        contextUserId: $profileUser->id,
+    );
+
+    expect($users->pluck('id')->all())
+        ->toBe($interactedUsers->take(5)->pluck('id')->all());
+});
+
+it('falls back to generic suggestions when profile context has no user id', function () {
+    $fallbackUser = User::factory()
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create(['is_verified' => true]);
+
+    $users = (new PeopleToFollowRecommendations())->forContext(
+        authenticatedUserId: null,
+        context: 'profile',
+        limit: 1,
+    );
+
+    expect($users->pluck('id')->all())
+        ->toBe([$fallbackUser->id]);
+});
+
+it('tops up profile suggestions with fallback users when interactions are not enough', function () {
+    $profileUser = User::factory()->create();
+
+    $interactedUsers = User::factory(2)->create();
+
+    $interactedUsers->each(function (User $interactedUser, int $index) use ($profileUser): void {
+        Question::factory()->create([
+            'from_id' => $interactedUser->id,
+            'to_id' => $profileUser->id,
+            'answer' => "Answer {$index}",
+            'updated_at' => now()->subMinutes($index),
+        ]);
+    });
+
+    $verifiedUsers = User::factory(2)
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(3, ['answer' => 'answer'])
+        ->create(['is_verified' => true]);
+
+    $famousUser = User::factory()
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(3, ['answer' => 'answer'])
+        ->create();
+
+    $users = (new PeopleToFollowRecommendations())->forContext(
+        authenticatedUserId: null,
+        context: 'profile',
+        contextUserId: $profileUser->id,
+    );
+
+    expect($users)
+        ->toHaveCount(5)
+        ->and($users->take(2)->pluck('id')->all())
+        ->toBe($interactedUsers->pluck('id')->all())
+        ->and($users->pluck('id')->all())
+        ->toContain($verifiedUsers[0]->id, $verifiedUsers[1]->id, $famousUser->id);
+});
+
+it('shows the post user and thread users on question pages before falling back to recent interactions', function () {
+    $postUser = User::factory()->create();
+    $rootParticipant = User::factory()->create();
+    $middleParticipant = User::factory()->create();
+    $currentParticipant = User::factory()->create();
+    $recentInteractionUser = User::factory()->create();
+
+    Question::factory()->create([
+        'from_id' => $recentInteractionUser->id,
+        'to_id' => $postUser->id,
+        'answer' => 'Recent interaction',
+        'updated_at' => now()->subMinutes(10),
+    ]);
+
+    $rootQuestion = Question::factory()->create([
+        'from_id' => $rootParticipant->id,
+        'to_id' => $postUser->id,
+        'updated_at' => now()->subMinutes(3),
+    ]);
+
+    $middleQuestion = Question::factory()->create([
+        'from_id' => $middleParticipant->id,
+        'to_id' => $postUser->id,
+        'parent_id' => $rootQuestion->id,
+        'updated_at' => now()->subMinutes(2),
+    ]);
+
+    $question = Question::factory()->create([
+        'from_id' => $currentParticipant->id,
+        'to_id' => $postUser->id,
+        'parent_id' => $middleQuestion->id,
+        'updated_at' => now()->subMinute(),
+    ]);
+
+    $users = (new PeopleToFollowRecommendations())->forContext(
+        authenticatedUserId: null,
+        context: 'question',
+        contextQuestionId: (string) $question->id,
+    );
+
+    expect($users->pluck('id')->all())
+        ->toBe([
+            $postUser->id,
+            $currentParticipant->id,
+            $middleParticipant->id,
+            $rootParticipant->id,
+            $recentInteractionUser->id,
+        ]);
+});
+
+it('falls back to generic suggestions when question context has no question id', function () {
+    $fallbackUser = User::factory()
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create(['is_verified' => true]);
+
+    $users = (new PeopleToFollowRecommendations())->forContext(
+        authenticatedUserId: null,
+        context: 'question',
+        limit: 1,
+    );
+
+    expect($users->pluck('id')->all())
+        ->toBe([$fallbackUser->id]);
+});
+
+it('falls back to generic suggestions when the question context cannot be found', function () {
+    $fallbackUser = User::factory()
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create(['is_verified' => true]);
+
+    $users = (new PeopleToFollowRecommendations())->forContext(
+        authenticatedUserId: null,
+        context: 'question',
+        contextQuestionId: 'missing-question-id',
+        limit: 1,
+    );
+
+    expect($users->pluck('id')->all())
+        ->toBe([$fallbackUser->id]);
+});
+
+it('widens the famous user search when the top fifty are unavailable', function () {
+    $user = User::factory()->create();
+
+    $topFiftyUsers = User::factory(50)
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create();
+
+    $overflowUsers = User::factory(5)
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(1, ['answer' => 'answer'])
+        ->create();
+
+    $user->following()->attach($topFiftyUsers);
+
+    $users = (new PeopleToFollowRecommendations())->forContext(authenticatedUserId: $user->id);
+
+    expect($users->pluck('id')->all())
+        ->toEqualCanonicalizing($overflowUsers->pluck('id')->all());
+});
+
+it('returns empty arrays from helper methods when the requested limit is zero', function () {
+    $recommendations = invade(new PeopleToFollowRecommendations());
+
+    expect($recommendations->latestInteractedUserIds(1, null, [], 0))
+        ->toBe([])
+        ->and($recommendations->genericFallbackUserIds(null, [], 0))
+        ->toBe([])
+        ->and($recommendations->verifiedUserIds(null, [], 0))
+        ->toBe([])
+        ->and($recommendations->famousUserIds(null, [], 0, 50))
+        ->toBe([])
+        ->and($recommendations->availableUserIds([1], null, [], 0))
+        ->toBe([]);
+});
+
+it('returns empty results when helper inputs collapse to no user ids', function () {
+    $recommendations = invade(new PeopleToFollowRecommendations());
+
+    expect($recommendations->usersForIds([]))
+        ->toBeEmpty()
+        ->and($recommendations->availableUserIds([0, -1, 0], null, [], 1))
+        ->toBe([]);
+});
+
+it('caches the top 50 users', function () {
+    User::factory(50)
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create();
+
+    (new PeopleToFollowRecommendations())->forContext(authenticatedUserId: null);
+
+    expect(Cache::has('top-50-users'))->toBeTrue();
+});

--- a/tests/Unit/Services/PeopleToFollowRecommendationsTest.php
+++ b/tests/Unit/Services/PeopleToFollowRecommendationsTest.php
@@ -277,6 +277,24 @@ it('returns empty results when helper inputs collapse to no user ids', function 
         ->toBe([]);
 });
 
+it('returns only available users when fewer qualify than the requested limit', function () {
+    // Only two users exist in the discovery pool — fewer than the default limit of
+    // five — so the post-fetch count check fires but finds nothing extra to top up.
+    User::factory(2)
+        ->hasLinks(1, function (array $attributes, User $user): array {
+            return ['url' => "https://twitter.com/{$user->username}"];
+        })
+        ->hasQuestionsReceived(2, ['answer' => 'answer'])
+        ->create();
+
+    $users = (new PeopleToFollowRecommendations())->forContext(
+        authenticatedUserId: null,
+        limit: 5,
+    );
+
+    expect($users)->toHaveCount(2);
+});
+
 it('caches the top 50 users', function () {
     User::factory(50)
         ->hasLinks(1, function (array $attributes, User $user): array {


### PR DESCRIPTION
Refactors the "People to Follow" widget from a simple random pool of 50 famous users into a context-aware recommendation engine that surfaces relevant people based on where the widget is rendered. Profile pages show recent interactors, question pages show thread participants, and everywhere else falls back to verified and famous users.