### PR TITLE
Fix: replace @turnstileScripts() with x-turnstile.scripts component 

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,6 +1,6 @@
 <x-guest-layout>
     @section('head')
-        @turnstileScripts()
+        <x-turnstile.scripts />
     @endsection
 
     <div class="mb-8">


### PR DESCRIPTION
**Before** :
<img width="1444" height="369" alt="Screenshot 2026-06-03 at 16 45 03" src="https://github.com/user-attachments/assets/7995fe8a-d05c-4b40-933b-e77e6a50f5db" />

**After** :
<img width="1444" height="369" alt="Screenshot 2026-06-03 at 16 50 03" src="https://github.com/user-attachments/assets/698cb721-50b0-45e2-ae2e-df65fc0a59e9" />

Replace the @turnstileScripts() directive with the <x-turnstile.scripts /> Blade component in the registration view (resources/views/auth/register.blade.php). This switches to the component-style syntax for including Turnstile scripts without changing behavior.