### PR TITLE
Fix: default feed on refresh

### DIFF
--- a/app/Http/Responses/HomeFeedResponse.php
+++ b/app/Http/Responses/HomeFeedResponse.php
@@ -23,15 +23,14 @@ final readonly class HomeFeedResponse
         if ($user instanceof User
             && $user->default_feed !== UserDefaultFeed::Recent
             && ! $request->hasHeader('X-Livewire-Navigate')
-            && ! session('_home_redirected')
+            && ! $request->cookies->has('_home_redirected')
         ) {
-            session(['_home_redirected' => true]);
-
-            return redirect()->route($user->default_feed->toRouteName());
+            return redirect()->route($user->default_feed->toRouteName())
+                ->withCookie(cookie('_home_redirected', true));
         }
 
-        if ($user instanceof User) {
-            session(['_home_redirected' => true]);
+        if ($user instanceof User && ! $request->cookies->has('_home_redirected')) {
+            cookie()->queue(cookie('_home_redirected', true));
         }
 
         return view('home/feed');

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,9 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->encryptCookies(except: [
-            '_home_redirected',
-        ]);
+        //
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->encryptCookies(except: [
+            '_home_redirected',
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -136,6 +136,19 @@
     updateTheme();
 </script>
 
+@if (request()->routeIs('home.feed'))
+    @auth
+        @if (auth()->user()->default_feed !== \App\Enums\UserDefaultFeed::Recent)
+            <script>
+                if (!sessionStorage.getItem('_home_redirected')) {
+                    sessionStorage.setItem('_home_redirected', '1');
+                    location.replace('{{ route(auth()->user()->default_feed->toRouteName()) }}');
+                }
+            </script>
+        @endif
+    @endauth
+@endif
+
 @livewireStyles
 @vite(['resources/css/app.css', 'resources/js/app.js'])
 

--- a/tests/Http/Home/FeedTest.php
+++ b/tests/Http/Home/FeedTest.php
@@ -64,9 +64,14 @@ it('shows recent feed to guest regardless of default feed setting', function ():
 it('shows recent feed on subsequent visits after initial redirect', function (): void {
     $user = User::factory()->create(['default_feed' => UserDefaultFeed::Following]);
 
-    $this->actingAs($user)->get(route('home.feed'))->assertSessionHas('_home_redirected', true);
+    $this->actingAs($user)
+        ->get(route('home.feed'))
+        ->assertRedirect(route('home.following'))
+        ->assertCookie('_home_redirected');
 
-    $response = $this->actingAs($user)->get(route('home.feed'));
+    $response = $this->actingAs($user)
+        ->withCookie('_home_redirected', '1')
+        ->get(route('home.feed'));
 
     $response->assertOk()
         ->assertSeeLivewire(Feed::class);


### PR DESCRIPTION
The session-based redirect seemed fine at first. First visit redirects to your default feed, and subsequent visits show Recent. But since the session lifetime is too long and persists across browser closes, the _home_redirected flag never resets, making Recent the effective default forever. I swapped it for a session cookie that actually expires when you close the browser, so you get redirected again on your next visit. But that still didn't cover closing just the last Pinkary tab (the cookie survives if other tabs are open). So I added a sessionStorage check in <head> that redirects instantly before any content renders.