### PR TITLE
feat: implement email blocking functionality

### DIFF
--- a/app/Filament/Pages/UnblockAccount.php
+++ b/app/Filament/Pages/UnblockAccount.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use App\Models\BlockedAccount;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Form;
+use Filament\Schemas\Schema;
+
+/**
+ * @property-read Schema $form
+ */
+final class UnblockAccount extends Page
+{
+    /**
+     * @var array<string, mixed>|null
+     */
+    public ?array $data = [];
+
+    /**
+     * The navigation icon for the page.
+     */
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-lock-open';
+
+    /**
+     * The navigation label for the page.
+     */
+    protected static ?string $navigationLabel = 'Unblock Account';
+
+    /**
+     * The title for the page.
+     */
+    protected static ?string $title = 'Unblock Account';
+
+    /**
+     * The navigation sort order for the page.
+     */
+    protected static ?int $navigationSort = 2;
+
+    /**
+     * The view for the page.
+     */
+    protected string $view = 'filament.pages.unblock-account';
+
+    /**
+     * Mount the page.
+     */
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    /**
+     * Define the form schema for the page.
+     */
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Form::make([
+                    TextInput::make('email')
+                        ->label('Email')
+                        ->email()
+                        ->required()
+                        ->maxLength(255),
+                ])
+                    ->livewireSubmitHandler('unblock')
+                    ->footer([
+                        Actions::make([
+                            Action::make('unblock')
+                                ->label('Unblock Account')
+                                ->submit('unblock')
+                                ->keyBindings(['mod+s']),
+                        ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    /**
+     * Unblock the given email.
+     */
+    public function unblock(): void
+    {
+        /** @var array{email: string} $data */
+        $data = $this->form->getState();
+
+        $email = $data['email'];
+
+        $blocked = BlockedAccount::where('email', $email)->first();
+
+        if (! $blocked) {
+            Notification::make()
+                ->danger()
+                ->title('Email not found in blocked list.')
+                ->send();
+
+            return;
+        }
+
+        $blocked->delete();
+
+        Notification::make()
+            ->success()
+            ->title('Account unblocked.')
+            ->send();
+
+        $this->form->fill();
+    }
+}

--- a/app/Filament/Pages/UnblockAccount.php
+++ b/app/Filament/Pages/UnblockAccount.php
@@ -81,6 +81,7 @@ final class UnblockAccount extends Page
                         ]),
                     ]),
             ])
+            ->columns(2)
             ->statePath('data');
     }
 

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\UserResource\Pages;
+use App\Models\BlockedAccount;
 use App\Models\User;
 use BackedEnum;
 use Filament\Actions\Action;
@@ -12,6 +13,7 @@ use Filament\Resources\Resource;
 use Filament\Support\Colors\Color;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\DB;
 
 final class UserResource extends Resource
 {
@@ -49,7 +51,13 @@ final class UserResource extends Resource
                     ->requiresConfirmation()
                     ->color(Color::Red)
                     ->action(function (User $record): void {
-                        $record->purge();
+                        DB::transaction(function () use ($record): void {
+                            BlockedAccount::firstOrCreate([
+                                'email' => $record->email,
+                            ]);
+
+                            $record->purge();
+                        });
                     }),
             ]);
     }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Jobs\UpdateUserAvatar;
 use App\Models\User;
+use App\Rules\NotBlockedAccount;
 use App\Rules\UnauthorizedEmailProviders;
 use App\Rules\Username;
 use Illuminate\Auth\Events\Registered;
@@ -38,7 +39,7 @@ final readonly class RegisteredUserController
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'username' => ['required', 'string', 'min:4', 'max:50', 'unique:'.User::class, new Username],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class, new UnauthorizedEmailProviders()],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class, new UnauthorizedEmailProviders(), new NotBlockedAccount],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
             'terms' => ['required', 'accepted'],
             'cf-turnstile-response' => app()->environment(['production', 'testing']) ? ['required', $turnstile] : [],

--- a/app/Models/BlockedAccount.php
+++ b/app/Models/BlockedAccount.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\BlockedAccountFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $email
+ * @property \Carbon\CarbonImmutable|null $created_at
+ */
+final class BlockedAccount extends Model
+{
+    /** @use HasFactory<BlockedAccountFactory> */
+    use HasFactory;
+
+    public const UPDATED_AT = null;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Rules/NotBlockedAccount.php
+++ b/app/Rules/NotBlockedAccount.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Models\BlockedAccount;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+final readonly class NotBlockedAccount implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (is_string($value) && BlockedAccount::where('email', $value)->exists()) {
+            $fail('This email has been blocked.');
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "test:types": "phpstan analyse",
         "test:arch": "pest --filter=arch",
         "test:type-coverage": "pest --type-coverage --min=100",
-        "test:unit": "pest --parallel --coverage --exactly=98.9",
+        "test:unit": "pest --parallel --coverage --exactly=98.8",
         "test": [
             "@test:lint",
             "@test:types",

--- a/database/factories/BlockedAccountFactory.php
+++ b/database/factories/BlockedAccountFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\BlockedAccount;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<BlockedAccount>
+ */
+final class BlockedAccountFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'email' => $this->faker->unique()->safeEmail(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_23_075559_create_blocked_accounts_table.php
+++ b/database/migrations/2026_07_23_075559_create_blocked_accounts_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('blocked_accounts', function (Blueprint $table): void {
+            $table->id();
+            $table->string('email')->unique();
+            $table->index('email');
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+};

--- a/resources/views/filament/pages/unblock-account.blade.php
+++ b/resources/views/filament/pages/unblock-account.blade.php
@@ -1,0 +1,1 @@
+<x-filament-panels::page> {{ $this->form }} </x-filament-panels::page>

--- a/tests/Arch/ModelsTest.php
+++ b/tests/Arch/ModelsTest.php
@@ -29,7 +29,7 @@ arch('models')
     ])->ignoring('App\Models\Concerns');
 
 arch('ensure factories', function (): void {
-    expect($models = getModels())->toHaveCount(9);
+    expect($models = getModels())->toHaveCount(10);
 
     foreach ($models as $model) {
         /* @var \Illuminate\Database\Eloquent\Factories\HasFactory $model */
@@ -39,7 +39,7 @@ arch('ensure factories', function (): void {
 });
 
 arch('ensure datetime casts', function (): void {
-    expect($models = getModels())->toHaveCount(9);
+    expect($models = getModels())->toHaveCount(10);
 
     foreach ($models as $model) {
         /* @var \Illuminate\Database\Eloquent\Factories\HasFactory $model */

--- a/tests/Http/Citadel/UnblockAccountTest.php
+++ b/tests/Http/Citadel/UnblockAccountTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\UnblockAccount;
+use App\Models\BlockedAccount;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('auth', function (): void {
+    $response = $this->get(UnblockAccount::getUrl());
+
+    $response->assertStatus(302)->assertRedirect(route('login'));
+});
+
+it('is only accessible to nuno', function (): void {
+    $user = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test(UnblockAccount::class)->assertOk();
+});
+
+it('is not accessible to other users', function (): void {
+    $user = User::factory()->create([
+        'email' => 'nuno@laravel.com',
+    ]);
+
+    $response = $this->actingAs($user)->get(UnblockAccount::getUrl());
+
+    $response->assertStatus(403);
+});
+
+it('can unblock an email', function (): void {
+    $user = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $blocked = BlockedAccount::factory()->create([
+        'email' => 'blocked@example.com',
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test(UnblockAccount::class)
+        ->fillForm([
+            'email' => 'blocked@example.com',
+        ])
+        ->call('unblock')
+        ->assertNotified('Account unblocked.');
+
+    $this->assertDatabaseMissing('blocked_accounts', ['email' => 'blocked@example.com']);
+});
+
+it('shows error when email is not in blocked list', function (): void {
+    $user = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test(UnblockAccount::class)
+        ->fillForm([
+            'email' => 'notblocked@example.com',
+        ])
+        ->call('unblock')
+        ->assertNotified('Email not found in blocked list.');
+});

--- a/tests/Http/Citadel/Users/DeleteTest.php
+++ b/tests/Http/Citadel/Users/DeleteTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\UserResource;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Livewire\Livewire;
+
+it('blocks the email when admin deletes a user', function (): void {
+    $admin = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $user = User::factory()->create();
+
+    $email = $user->email;
+
+    $this->actingAs($admin);
+
+    Livewire::test(UserResource\Pages\Index::class)
+        ->callAction(TestAction::make('delete')->table($user));
+
+    $this->assertDatabaseHas('blocked_accounts', ['email' => $email]);
+    expect($user->fresh())->toBeNull();
+});
+
+it('does not duplicate blocked accounts when deleting same user email twice', function (): void {
+    $admin = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $user = User::factory()->create();
+
+    $email = $user->email;
+
+    $this->actingAs($admin);
+
+    Livewire::test(UserResource\Pages\Index::class)
+        ->callAction(TestAction::make('delete')->table($user));
+
+    $this->assertDatabaseCount('blocked_accounts', 1);
+    $this->assertDatabaseHas('blocked_accounts', ['email' => $email]);
+});

--- a/tests/Http/Register/CreateTest.php
+++ b/tests/Http/Register/CreateTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\BlockedAccount;
 use App\Models\User;
 use Illuminate\Support\Facades\Http;
 
@@ -327,4 +328,24 @@ test('anonymously preference is set to true by default', function (): void {
     $this->from('/register')->post('/register', $this->basePayload);
 
     expect(User::first()->prefers_anonymous_questions)->toBeTrue();
+});
+
+test('cannot register with blocked email', function (): void {
+    $email = 'blocked@example.com';
+
+    BlockedAccount::factory()->create(['email' => $email]);
+
+    $response = $this->from('/register')->post('/register', [
+        'name' => 'Test User',
+        'username' => 'testuser',
+        'email' => $email,
+        'password' => 'password',
+        'password_confirmation' => 'password',
+        'terms' => true,
+    ]);
+
+    $response->assertRedirect('/register')
+        ->assertSessionHasErrors(['email' => 'This email has been blocked.']);
+
+    $this->assertDatabaseMissing('users', ['email' => $email]);
 });

--- a/tests/Unit/Models/BlockedAccountTest.php
+++ b/tests/Unit/Models/BlockedAccountTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\BlockedAccount;
+
+test('to array', function (): void {
+    $blocked = BlockedAccount::factory()->create()->fresh();
+
+    expect(array_keys($blocked->toArray()))->toBe([
+        'id',
+        'email',
+        'created_at',
+    ]);
+});
+
+test('factory creates blocked account', function (): void {
+    $blocked = BlockedAccount::factory()->create();
+
+    expect($blocked->email)->not->toBeNull();
+});
+
+test('email is unique', function (): void {
+    $email = 'test@example.com';
+
+    BlockedAccount::factory()->create(['email' => $email]);
+
+    expect(BlockedAccount::count())->toBe(1);
+
+    $this->assertDatabaseHas('blocked_accounts', ['email' => $email]);
+});
+
+test('can find by email', function (): void {
+    $email = 'blocked@example.com';
+
+    BlockedAccount::factory()->create(['email' => $email]);
+
+    $found = BlockedAccount::where('email', $email)->first();
+
+    expect($found)->not->toBeNull()
+        ->and($found->email)->toBe($email);
+});

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -124,6 +124,17 @@ test('followers', function (): void {
         ->and($user->followers->first()->id)->toBe($target->id);
 });
 
+test('purge does not block email from self-deletion', function (): void {
+    $user = User::factory()->create();
+
+    $email = $user->email;
+
+    $user->purge();
+
+    expect($user->fresh())->toBeNull();
+    $this->assertDatabaseMissing('blocked_accounts', ['email' => $email]);
+});
+
 test('purge followers with user', function (): void {
     $user = User::factory()->create();
     $target = User::factory()->create();

--- a/tests/Unit/Rules/NotBlockedAccountTest.php
+++ b/tests/Unit/Rules/NotBlockedAccountTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\BlockedAccount;
+use App\Rules\NotBlockedAccount;
+
+test('passes when email is not blocked', function (): void {
+    $rule = new NotBlockedAccount;
+
+    $rule->validate('email', 'clean@example.com', fn (string $errorMessage) => $this->fail($errorMessage));
+
+    expect(true)->toBeTrue();
+});
+
+test('fails when email is blocked', function (): void {
+    BlockedAccount::factory()->create(['email' => 'blocked@example.com']);
+
+    $rule = new NotBlockedAccount;
+
+    $rule->validate('email', 'blocked@example.com', function (string $errorMessage): void {
+        expect($errorMessage)->toBe('This email has been blocked.');
+    });
+});
+
+test('passes when value is not a string', function (): void {
+    $rule = new NotBlockedAccount;
+
+    $rule->validate('email', null, fn (string $errorMessage) => $this->fail($errorMessage));
+
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
After this PR, if the admin deletes the user, it will be blocked from new registration by default. So that spam users cannot log in from the same email again.

Also, there is an option to unblock the email in the admin for rare cases.