### PR TITLE
fix: sanitize the Turnstile ID on reply forms

### DIFF
--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -29,6 +29,7 @@ use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
  * @property-read bool $isSharingUpdate
  * @property-read int $maxContentLength
  * @property-read int $needsCaptcha
+ * @property-read string $turnstileId
  */
 final class Create extends Component
 {
@@ -218,6 +219,17 @@ final class Create extends Component
         return filled($this->parentId)
             ? "reply_{$this->parentId}"
             : 'post_new';
+    }
+
+    /**
+     * Get the captcha widget ID, restricted to the characters allowed by Turnstile.
+     */
+    #[Computed]
+    public function turnstileId(): string
+    {
+        $id = $this->draftKey().'_turnstile_'.($this->toId ?? 'global');
+
+        return (string) preg_replace('/[^A-Za-z0-9_]/', '_', $id);
     }
 
     /**

--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -114,11 +114,7 @@
                     wire.ignore
                 >
                     <div class="flex justify-center">
-                        <x-turnstile
-                            id="{{ $this->draftKey }}_turnstile_{{ $this->toId ?? 'global' }}"
-                            wire:model="cfTurnstileResponse"
-                            data-theme="auto"
-                        />
+                        <x-turnstile id="{{ $this->turnstileId }}" wire:model="cfTurnstileResponse" data-theme="auto" />
                     </div>
 
                     <x-input-error :messages="$errors->get('cfTurnstileResponse')" class="mt-3 text-center" />

--- a/tests/Http/Profile/Show/Questions/ShowTest.php
+++ b/tests/Http/Profile/Show/Questions/ShowTest.php
@@ -7,6 +7,7 @@ use App\Livewire\Questions\Create;
 use App\Livewire\Questions\Show;
 use App\Models\Question;
 use App\Models\User;
+use RyanChandler\LaravelCloudflareTurnstile\Facades\Turnstile;
 
 test('guest', function (): void {
     $question = Question::factory()->create([
@@ -45,6 +46,28 @@ test('auth', function (): void {
 
     $response->assertSeeLivewire(Show::class);
     $response->assertSeeLivewire(Create::class);
+});
+
+test('auth without followers renders the captcha on the reply form', function (): void {
+    app()->detectEnvironment(fn (): string => 'production');
+    Turnstile::fake();
+
+    $user = User::factory()->create();
+
+    expect($user->followers()->count())->toBe(0);
+
+    $question = Question::factory()->create([
+        'answer' => 'This is the answer',
+    ]);
+
+    $response = $this->actingAs($user)->get(route('questions.show', [
+        'username' => $question->to->username,
+        'question' => $question->id,
+    ]));
+
+    $response->assertOk();
+    $response->assertSeeLivewire(Create::class);
+    $response->assertSee('cf-turnstile', escape: false);
 });
 
 test('answer translate action is visible before bookmarks', function (): void {

--- a/tests/Unit/Livewire/Questions/CreateTest.php
+++ b/tests/Unit/Livewire/Questions/CreateTest.php
@@ -109,6 +109,24 @@ test('users with zero followers pass captcha and can store', function (): void {
         ->and($question->content)->toBe('Hello from zero followers');
 });
 
+test('renders the captcha on replies, whose parent id contains characters turnstile rejects', function (): void {
+    app()->detectEnvironment(fn (): string => 'production');
+    Turnstile::fake();
+
+    $user = User::factory()->create();
+    $parent = Question::factory()->create();
+
+    expect($parent->id)->toContain('-');
+
+    /** @var Testable $component */
+    $component = Livewire::actingAs($user)->test(Create::class, [
+        'parentId' => $parent->id,
+    ]);
+
+    $component->assertOk()
+        ->assertSeeHtml('data-callback="reply_'.str_replace('-', '_', $parent->id).'_turnstile_globalCallback"');
+});
+
 test('store auth', function (): void {
     $user = User::factory()->create();
 


### PR DESCRIPTION
Question IDs are UUIDs, so the reply form built a Turnstile ID such as `reply_9b7a86a8-2de5-4a6e-a432-c191dd1ac2cd_turnstile_1`. The package uses that value as a JavaScript global variable name, so it rejects any character outside `[A-Za-z0-9_]` and threw, 500ing every question page for logged-in users with no followers.

Replace the disallowed characters with underscores in a dedicated computed property. IDs stay unique per component instance.