### PR TITLE
Add post text formatting controls

### DIFF
--- a/app/Services/ParsableContent.php
+++ b/app/Services/ParsableContent.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Contracts\Services\ParsableContentProvider;
 use App\Services\ParsableContentProviders\BrProviderParsable;
 use App\Services\ParsableContentProviders\CodeProviderParsable;
+use App\Services\ParsableContentProviders\FormattingProviderParsable;
 use App\Services\ParsableContentProviders\HashtagProviderParsable;
 use App\Services\ParsableContentProviders\ImageProviderParsable;
 use App\Services\ParsableContentProviders\LinkProviderParsable;
@@ -24,6 +25,7 @@ final readonly class ParsableContent
         StripProviderParsable::class,
         CodeProviderParsable::class,
         ImageProviderParsable::class,
+        FormattingProviderParsable::class,
         BrProviderParsable::class,
         LinkProviderParsable::class,
         MentionProviderParsable::class,

--- a/app/Services/ParsableContentProviders/FormattingProviderParsable.php
+++ b/app/Services/ParsableContentProviders/FormattingProviderParsable.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ParsableContentProviders;
+
+use App\Contracts\Services\ParsableContentProvider;
+
+final readonly class FormattingProviderParsable implements ParsableContentProvider
+{
+    /**
+     * Parse the supported Markdown-style formatting.
+     */
+    public function parse(string $content): string
+    {
+        $parts = preg_split('/(<(?:pre|code|a|img)\b[^>]*>.*?<\/(?:pre|code|a)>|<img\b[^>]*>)/is', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        if ($parts === false) {
+            return $content;
+        }
+
+        return implode('', array_map(function (string $part): string {
+            if (preg_match('/^<(?:pre|code|a|img)\b/i', $part) === 1) {
+                return $part;
+            }
+
+            $part = (string) preg_replace_callback(
+                '/\[([^\]\n]+)]\((https?:\/\/[^\s)]+)\)/i',
+                static function (array $matches): string {
+                    $url = html_entity_decode($matches[2], ENT_QUOTES | ENT_HTML5);
+
+                    if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+                        return $matches[0];
+                    }
+
+                    return sprintf(
+                        '<a data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" target="_blank" rel="noopener noreferrer" href="%s">%s</a>',
+                        e($url),
+                        $matches[1],
+                    );
+                },
+                $part,
+            );
+
+            $part = (string) preg_replace('/\*\*([^*\n]+)\*\*/', '<strong>$1</strong>', $part);
+            $part = (string) preg_replace('/(?<!\*)\*([^*\n]+)\*(?!\*)/', '<em>$1</em>', $part);
+
+            return (string) preg_replace(
+                '/^&gt;[ \t]?(.*)$/m',
+                '<blockquote class="border-l-4 border-slate-300 pl-3 text-slate-600 dark:border-slate-600 dark:text-slate-300">$1</blockquote>',
+                $part,
+            );
+        }, $parts));
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,75 +1,81 @@
-import './bootstrap'
-import autosize from 'autosize';
-import notifications from 'alpinejs-notify'
-import Sortable from 'sortablejs'
-import { Livewire, Alpine } from '../../vendor/livewire/livewire/dist/livewire.esm'
+import "./bootstrap";
+import autosize from "autosize";
+import notifications from "alpinejs-notify";
+import Sortable from "sortablejs";
+import {
+    Livewire,
+    Alpine,
+} from "../../vendor/livewire/livewire/dist/livewire.esm";
 
-window.Alpine = Alpine
-window.Sortable = Sortable
+window.Alpine = Alpine;
+window.Sortable = Sortable;
 
-Alpine.plugin(notifications)
+Alpine.plugin(notifications);
 
-Alpine.magic('clipboard', () => {
-    return subject => navigator.clipboard.writeText(subject)
-})
+Alpine.magic("clipboard", () => {
+    return (subject) => navigator.clipboard.writeText(subject);
+});
 
-Alpine.directive('sortable', (el) => {
+Alpine.directive("sortable", (el) => {
     el.sortable = Sortable.create(el, {
-        draggable: '[x-sortable-item]',
-        handle: '[x-sortable-handle]',
-        dataIdAttr: 'x-sortable-item',
+        draggable: "[x-sortable-item]",
+        handle: "[x-sortable-handle]",
+        dataIdAttr: "x-sortable-item",
         animation: 300,
-        ghostClass: 'opacity-30',
-    })
-})
+        ghostClass: "opacity-30",
+    });
+});
 
-Alpine.directive('autosize', (el) => {
+Alpine.directive("autosize", (el) => {
     if (el) {
         autosize(el);
     }
 });
 
-import { shareProfile } from './share-profile.js'
-Alpine.data('shareProfile', shareProfile)
+import { shareProfile } from "./share-profile.js";
+Alpine.data("shareProfile", shareProfile);
 
-import { copyUrl } from './copy-url.js'
-Alpine.data('copyUrl', copyUrl)
+import { copyUrl } from "./copy-url.js";
+Alpine.data("copyUrl", copyUrl);
 
-import { showMore } from './show-more.js'
-Alpine.data('showMore', showMore)
+import { showMore } from "./show-more.js";
+Alpine.data("showMore", showMore);
 
-import { clickHandler } from './click-handler.js'
-Alpine.data('clickHandler', clickHandler)
+import { clickHandler } from "./click-handler.js";
+Alpine.data("clickHandler", clickHandler);
 
-import { copyCode } from './copy-code.js'
-Alpine.data('copyCode', copyCode)
+import { copyCode } from "./copy-code.js";
+Alpine.data("copyCode", copyCode);
 
-import { imageUpload } from './image-upload.js'
-Alpine.data('imageUpload', imageUpload)
+import { imageUpload } from "./image-upload.js";
+Alpine.data("imageUpload", imageUpload);
 
 import { autocomplete, usesAutocomplete } from "./autocomplete.js";
-Alpine.data('dynamicAutocomplete', autocomplete);
-Alpine.data('usesDynamicAutocomplete', usesAutocomplete);
+Alpine.data("dynamicAutocomplete", autocomplete);
+Alpine.data("usesDynamicAutocomplete", usesAutocomplete);
 
-import { hasLightBoxImages, lightBox } from './light-box.js';
-Alpine.data('hasLightBoxImages', hasLightBoxImages);
-Alpine.data('lightBox', lightBox);
+import { hasLightBoxImages, lightBox } from "./light-box.js";
+Alpine.data("hasLightBoxImages", hasLightBoxImages);
+Alpine.data("lightBox", lightBox);
 
-import { likeButton } from './like-button.js';
-Alpine.data('likeButton', likeButton);
+import { likeButton } from "./like-button.js";
+Alpine.data("likeButton", likeButton);
 
-import { bookmarkButton } from './bookmark-button.js';
-Alpine.data('bookmarkButton', bookmarkButton);
-import { followButton } from './follow-button.js'
-Alpine.data('followButton', followButton)
+import { bookmarkButton } from "./bookmark-button.js";
+Alpine.data("bookmarkButton", bookmarkButton);
+import { followButton } from "./follow-button.js";
+Alpine.data("followButton", followButton);
 
-import { viewCreate } from './view-cerate.js';
-Alpine.data('viewCreate', viewCreate);
+import { viewCreate } from "./view-cerate.js";
+Alpine.data("viewCreate", viewCreate);
 
-import { themeSwitch } from './theme-switch.js';
-Alpine.data('themeSwitch', themeSwitch);
+import { themeSwitch } from "./theme-switch.js";
+Alpine.data("themeSwitch", themeSwitch);
 
-import { poll } from './poll.js';
-Alpine.data('poll', poll);
+import { poll } from "./poll.js";
+Alpine.data("poll", poll);
 
-Livewire.start()
+import { formattingToolbar } from "./formatting-toolbar.js";
+Alpine.data("formattingToolbar", formattingToolbar);
+
+Livewire.start();

--- a/resources/js/formatting-toolbar.js
+++ b/resources/js/formatting-toolbar.js
@@ -1,0 +1,77 @@
+export function formattingToolbar() {
+    return {
+        format(event, prefix, suffix = prefix, placeholder = "text") {
+            const textarea = event.currentTarget
+                .closest("[x-data]")
+                ?.querySelector('textarea[x-ref="content"]');
+
+            if (!textarea) {
+                return;
+            }
+
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            const selected = textarea.value.slice(start, end) || placeholder;
+            const replacement = `${prefix}${selected}${suffix}`;
+
+            if (
+                textarea.maxLength > 0 &&
+                textarea.value.length - (end - start) + replacement.length >
+                    textarea.maxLength
+            ) {
+                return;
+            }
+
+            textarea.setRangeText(replacement, start, end, "end");
+            textarea.dispatchEvent(new Event("input", { bubbles: true }));
+            textarea.focus();
+
+            if (start === end) {
+                textarea.setSelectionRange(
+                    start + prefix.length,
+                    start + prefix.length + placeholder.length,
+                );
+            }
+        },
+
+        quote(event) {
+            const textarea = event.currentTarget
+                .closest("[x-data]")
+                ?.querySelector('textarea[x-ref="content"]');
+
+            if (!textarea) {
+                return;
+            }
+
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            const selected = textarea.value.slice(start, end) || "quoted text";
+            const replacement = selected
+                .split("\n")
+                .map((line) => `> ${line}`)
+                .join("\n");
+
+            if (
+                textarea.maxLength > 0 &&
+                textarea.value.length - (end - start) + replacement.length >
+                    textarea.maxLength
+            ) {
+                return;
+            }
+
+            textarea.setRangeText(replacement, start, end, "end");
+            textarea.dispatchEvent(new Event("input", { bubbles: true }));
+            textarea.focus();
+        },
+
+        link(event) {
+            const url = window.prompt("Enter the link URL", "https://");
+
+            if (!url || !/^https?:\/\//i.test(url)) {
+                return;
+            }
+
+            this.format(event, "[", `](${url})`, "link text");
+        },
+    };
+}

--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -24,7 +24,13 @@
     >
         <div class="min-w-0">
             <div class="group/menu relative">
-                <div x-data="{ content: $persist($wire.entangle('content')).as('{{ $this->draftKey }}') }" class="p-0">
+                <div
+                    x-data="{
+                        ...formattingToolbar(),
+                        content: $persist($wire.entangle('content')).as('{{ $this->draftKey }}'),
+                    }"
+                    class="p-0"
+                >
                     <x-textarea
                         x-model="content"
                         placeholder="{{ $this->placeholder }}"
@@ -37,14 +43,83 @@
                         class="min-h-20! rounded-none! border-slate-200/70! bg-white! px-3.5! py-3! text-[0.95rem]! leading-7! text-slate-950! shadow-sm placeholder:text-slate-400! dark:border-slate-800/30! dark:bg-[#10182b]! dark:text-white! dark:placeholder:text-slate-500!"
                     />
 
+                    <div
+                        class="flex items-center gap-1 border-x border-b border-slate-200/70 bg-slate-50 px-2 py-1.5 dark:border-slate-800/30 dark:bg-[#0b1324]"
+                        role="toolbar"
+                        aria-label="Text formatting"
+                    >
+                        <button
+                            type="button"
+                            x-on:click="format($event, '**')"
+                            title="Bold"
+                            aria-label="Bold"
+                            class="flex size-8 items-center justify-center font-bold text-slate-500 hover:bg-slate-200/70 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+                        >
+                            B
+                        </button>
+                        <button
+                            type="button"
+                            x-on:click="format($event, '*')"
+                            title="Italic"
+                            aria-label="Italic"
+                            class="flex size-8 items-center justify-center font-serif italic text-slate-500 hover:bg-slate-200/70 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+                        >
+                            I
+                        </button>
+                        <button
+                            type="button"
+                            x-on:click="quote($event)"
+                            title="Quote"
+                            aria-label="Quote"
+                            class="flex size-8 items-center justify-center text-lg text-slate-500 hover:bg-slate-200/70 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+                        >
+                            “
+                        </button>
+                        <button
+                            type="button"
+                            x-on:click="link($event)"
+                            title="Link"
+                            aria-label="Link"
+                            class="flex size-8 items-center justify-center text-slate-500 hover:bg-slate-200/70 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+                        >
+                            <x-heroicon-o-link class="size-4" />
+                        </button>
+                        <button
+                            type="button"
+                            x-on:click="format($event, '```\n', '\n```', 'code')"
+                            title="Code block"
+                            aria-label="Code block"
+                            class="flex size-8 items-center justify-center font-mono text-slate-500 hover:bg-slate-200/70 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+                        >
+                            &lt;/&gt;
+                        </button>
+                    </div>
+
                     <p class="mt-2 text-right text-sm text-slate-500 dark:text-slate-400">
-                        <span x-text="$wire.content.length"></span> / {{ $this->maxContentLength }}
+                        <span x-text="$wire.content.length"></span>
+                        / {{ $this->maxContentLength }}
                     </p>
                 </div>
-                <input class="hidden" type="file" x-ref="imageInput" multiple accept="image/*" />
-                <input class="hidden" type="file" x-ref="imageUpload" multiple accept="image/*" wire:model="images" />
+                <input
+                    class="hidden"
+                    type="file"
+                    x-ref="imageInput"
+                    multiple
+                    accept="image/*"
+                />
+                <input
+                    class="hidden"
+                    type="file"
+                    x-ref="imageUpload"
+                    multiple
+                    accept="image/*"
+                    wire:model="images"
+                />
 
-                <div x-show="images.length > 0" class="relative mt-3 flex flex-wrap gap-2">
+                <div
+                    x-show="images.length > 0"
+                    class="relative mt-3 flex flex-wrap gap-2"
+                >
                     <template x-for="(image, index) in images" :key="index">
                         <div class="relative h-20 w-20">
                             <img
@@ -66,7 +141,9 @@
 
                 <ul>
                     <template x-for="(error, index) in errors" :key="index">
-                        <li class="w-full py-2 text-sm text-red-500"><span x-text="error"></span></li>
+                        <li class="w-full py-2 text-sm text-red-500">
+                            <span x-text="error"></span>
+                        </li>
                     </template>
                 </ul>
             </div>
@@ -83,7 +160,10 @@
                         x-ref="imageButton"
                         :disabled="uploading || images.length >= uploadLimit"
                         class="flex size-10 items-center justify-center border border-slate-200/70 bg-white text-sm text-slate-500 transition hover:bg-slate-100 hover:text-slate-950 dark:border-slate-800/30 dark:bg-[#10182b] dark:text-slate-400 dark:hover:bg-[#162038] dark:hover:text-white"
-                        :class="{ 'cursor-not-allowed text-pink-500': uploading || images.length >= uploadLimit }"
+                        :class="{
+                            'cursor-not-allowed text-pink-500':
+                                uploading || images.length >= uploadLimit,
+                        }"
                     >
                         <x-heroicon-o-photo class="h-5 w-5" />
                     </button>
@@ -100,11 +180,16 @@
                     @endif
                 </div>
                 @if (! $this->parentId && ! $this->isSharingUpdate)
-                    <div class="flex items-center border border-slate-200/70 bg-white px-3 py-2 dark:border-slate-800/30 dark:bg-[#10182b]">
+                    <div
+                        class="flex items-center border border-slate-200/70 bg-white px-3 py-2 dark:border-slate-800/30 dark:bg-[#10182b]"
+                    >
                         <x-checkbox wire:model="anonymously" id="anonymously" />
 
-                        <label for="anonymously" class="ml-2 text-sm text-slate-500 dark:text-slate-400"
-                            >Anonymously</label>
+                        <label
+                            for="anonymously"
+                            class="ml-2 text-sm text-slate-500 dark:text-slate-400"
+                            >Anonymously</label
+                        >
                     </div>
                 @endif
             </div>
@@ -114,20 +199,33 @@
                     wire.ignore
                 >
                     <div class="flex justify-center">
-                        <x-turnstile id="{{ $this->turnstileId }}" wire:model="cfTurnstileResponse" data-theme="auto" />
+                        <x-turnstile
+                            id="{{ $this->turnstileId }}"
+                            wire:model="cfTurnstileResponse"
+                            data-theme="auto"
+                        />
                     </div>
 
-                    <x-input-error :messages="$errors->get('cfTurnstileResponse')" class="mt-3 text-center" />
+                    <x-input-error
+                        :messages="$errors->get('cfTurnstileResponse')"
+                        class="mt-3 text-center"
+                    />
                 </div>
             @endif
         </div>
 
         <div x-show="isPoll" class="mt-4 space-y-4" style="display: none">
             <div class="space-y-2">
-                <h4 class="text-sm font-medium text-slate-700 dark:text-slate-300">Poll Options</h4>
+                <h4
+                    class="text-sm font-medium text-slate-700 dark:text-slate-300"
+                >
+                    Poll Options
+                </h4>
                 <template x-for="(option, index) in pollOptions" :key="index">
                     <div class="flex items-center gap-2">
-                        <div class="h-4 w-4 shrink-0 rounded-full border-2 border-slate-300 dark:border-slate-600"></div>
+                        <div
+                            class="h-4 w-4 shrink-0 rounded-full border-2 border-slate-300 dark:border-slate-600"
+                        ></div>
                         <x-text-input
                             x-model="pollOptions[index]"
                             ::placeholder="`Option ${index + 1}`"
@@ -158,7 +256,10 @@
             </div>
 
             <div>
-                <label for="pollDuration" class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                <label
+                    for="pollDuration"
+                    class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300"
+                >
                     Poll Duration
                 </label>
                 <select

--- a/tests/Unit/Services/ContentProvidersTest.php
+++ b/tests/Unit/Services/ContentProvidersTest.php
@@ -10,6 +10,31 @@ beforeEach(function (): void {
     ]);
 });
 
+test('text formatting', function (string $content, string $parsed): void {
+    $provider = new App\Services\ParsableContentProviders\FormattingProviderParsable();
+
+    expect($provider->parse($content))->toBe($parsed);
+})->with([
+    ['**bold**', '<strong>bold</strong>'],
+    ['*italic*', '<em>italic</em>'],
+    ['&gt; quoted text', '<blockquote class="border-l-4 border-slate-300 pl-3 text-slate-600 dark:border-slate-600 dark:text-slate-300">quoted text</blockquote>'],
+    ['[Laravel](https://laravel.com)', '<a data-navigate-ignore="true" class="text-blue-500 hover:underline hover:text-blue-700 cursor-pointer" target="_blank" rel="noopener noreferrer" href="https://laravel.com">Laravel</a>'],
+]);
+
+test('formatting keeps unsafe and unsupported links as text', function (): void {
+    $provider = new App\Services\ParsableContentProviders\FormattingProviderParsable();
+
+    expect($provider->parse('[unsafe](javascript:alert(1))'))
+        ->toBe('[unsafe](javascript:alert(1))');
+});
+
+test('formatting ignores generated html elements', function (): void {
+    $provider = new App\Services\ParsableContentProviders\FormattingProviderParsable();
+
+    expect($provider->parse('<pre><code>**not bold**</code></pre> **bold**'))
+        ->toBe('<pre><code>**not bold**</code></pre> <strong>bold</strong>');
+});
+
 test('brs', function (string $content, string $parsed): void {
     $provider = new App\Services\ParsableContentProviders\BrProviderParsable();
 


### PR DESCRIPTION
## Description

Adds text formatting controls to the post editor to make formatting more accessible, especially for non-technical users.

## Changes

- Added formatting controls to the post editor.
- Added support for common text formatting actions.
- Improved the post creation experience without requiring users to manually write formatting syntax.

## Related issue

Closes #702
<img width="689" height="550" alt="Screenshot 2026-08-10 at 4 37 29 p m" src="https://github.com/user-attachments/assets/4cbfa5cb-9244-466a-94fa-c9f0d742e4b0" />
