### PR TITLE
fix(ui): align bookmarks and notifications page layout with feed container

### DIFF
--- a/resources/views/bookmarks/index.blade.php
+++ b/resources/views/bookmarks/index.blade.php
@@ -1,8 +1,10 @@
 <x-app-layout>
-    <x-slot name="title">Bookmarks</x-slot>
+    <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+        <div class="sticky -top-1 z-30 flex items-center justify-between border-b border-slate-200/70 bg-white px-6 py-4 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
+            <h2 class="text-[2rem] font-semibold tracking-tight text-slate-950 dark:text-white">Bookmarks</h2>
+        </div>
 
-    <section class="border-b border-slate-200/70 bg-white/80 px-4 py-4 lg:border-r dark:border-slate-800/30 dark:bg-[#07101f]/95">
-        <div class="mx-auto min-h-screen w-full max-w-176 overflow-hidden">
+        <div class="min-h-screen p-4 sm:p-6">
             <livewire:bookmarks />
         </div>
     </section>

--- a/resources/views/livewire/bookmarks/index.blade.php
+++ b/resources/views/livewire/bookmarks/index.blade.php
@@ -1,6 +1,6 @@
-<div class="mb-20">
+<div class="mb-20 space-y-4">
     @forelse ($bookmarks as $bookmark)
-        <div class="border-b border-slate-200 px-0 py-6 first:pt-0 dark:border-slate-700/50">
+        <div class="border-b border-slate-200 py-2 dark:border-slate-700/50">
             <livewire:questions.show
                 :questionId="$bookmark->question->id"
                 :key="'question-'.$bookmark->question->id"

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -1,8 +1,10 @@
 <x-app-layout>
-    <x-slot name="title">Notifications</x-slot>
+    <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+        <div class="sticky -top-1 z-30 flex items-center justify-between border-b border-slate-200/70 bg-white px-6 py-4 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
+            <h2 class="text-[2rem] font-semibold tracking-tight text-slate-950 dark:text-white">Notifications</h2>
+        </div>
 
-    <section class="border-b border-slate-200/70 bg-white/80 px-4 py-4 lg:border-r dark:border-slate-800/30 dark:bg-[#07101f]/95">
-        <div class="mx-auto min-h-screen w-full max-w-176 overflow-hidden">
+        <div class="min-h-screen p-4 sm:p-6">
             <livewire:notifications-index />
         </div>
     </section>


### PR DESCRIPTION
### Summary
This PR aligns the \/bookmarks\ and \/notifications\ pages with Pinkary's standard elevated feed column layout (\order-x border-b dark:bg-[#07101f]/95\) and sticky header bar.

### Changes
- **Page Container**: Wrapped \/bookmarks\ and \/notifications\ in the standard feed section container to prevent background bleed and eliminate visual inconsistencies.
- **Header Alignment**: Integrated sticky header bar with standardized padding (\px-6 py-4 sm:py-6\) and typography (\	ext-[2rem] font-semibold tracking-tight\).
- **Inner Padding**: Standardized content spacing (\p-4 sm:p-6\) and empty state dashed boxes across both pages.