### PR TITLE
fix: soften AI block page copy

### DIFF
--- a/resources/views/errors/access-denied.blade.php
+++ b/resources/views/errors/access-denied.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="robots" content="noindex, nofollow" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Access Denied</title>
+    <title>Content Not Available</title>
     <style>
         body {
             background: #f8fafc;
@@ -34,7 +34,7 @@
 <body>
     <div class="content">
         <h1>403</h1>
-        <p>Access Denied</p>
+        <p>This content isn't available for AI browsers and agents.</p>
     </div>
 </body>
 </html>

--- a/tests/Unit/Middleware/BlockBotsTest.php
+++ b/tests/Unit/Middleware/BlockBotsTest.php
@@ -29,7 +29,7 @@ test('blocks GPTBot with a 403 response', function (): void {
 
     $this->get('/test-block-bots', ['User-Agent' => 'Mozilla/5.0 (compatible; GPTBot/1.0; +https://openai.com/bot)'])
         ->assertStatus(403)
-        ->assertSee('Access Denied');
+        ->assertSee("This content isn't available for AI browsers and agents.", false);
 });
 
 test('blocks ClaudeBot with a 403 response', function (): void {


### PR DESCRIPTION
## Summary

Follow-up to #849. Keeps the **403 status** for blocked AI crawlers/headless browsers but replaces the harsh *Access Denied* message with a friendlier explanation.

## Changes

- `resources/views/errors/access-denied.blade.php`
  - Page title: `Access Denied` → `Content Not Available`
  - Body copy: `Access Denied` → "This content isn't available for AI browsers and agents."
- `tests/Unit/Middleware/BlockBotsTest.php` — assertion updated to the new copy

## Why keep the 403?

- Correct HTTP semantics: the request is understood but not allowed
- Crawlers treat 4xx as a stop/deprioritize signal; a soft 200 would read as success
- Blocked traffic stays measurable in logs/analytics (consistent with standard bot-blocking behavior)
