### PR TITLE
Add composer setup script to composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,17 @@ git checkout -b feat/your-feature # or fix/your-fix
 
 > **Don't push directly to the `main` branch**. Instead, create a new branch and push it to your branch.
 
-Next, install the dependencies using [Composer](https://getcomposer.org) and [NPM](https://www.npmjs.com):
+Two ways to set up the project:
+
+### Automated Setup
+
+```bash
+composer setup
+```
+
+### Manual Setup
+
+Install the dependencies using [Composer](https://getcomposer.org) and [NPM](https://www.npmjs.com):
 
 ```bash
 composer install
@@ -63,13 +73,17 @@ Link the storage to the public folder:
 php artisan storage:link
 ```
 
-In a **separate terminal**, build the assets in watch mode:
+### Running the Project
+
+Regardless of which setup path you chose, run these in **separate terminals**.
+
+Build the assets in watch mode:
 
 ```bash
 npm run dev
 ```
 
-Also in a **separate terminal**, run the queue worker:
+Run the queue worker:
 
 ```bash
 php artisan queue:work

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,14 @@
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan migrate --ansi"
         ],
+        "setup": [
+            "composer install",
+            "npm install",
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
+            "@php artisan key:generate --ansi",
+            "@php artisan migrate --ansi",
+            "@php artisan storage:link --ansi"
+        ],
         "bump:minor": [
             "composer update && composer bump",
             "npx npm-check-updates -u -t minor && npm install"


### PR DESCRIPTION
## What

Add `composer setup` script and document it in the README alongside the manual setup path.

## Why

Onboarding currently requires copy-pasting six commands in order. `composer setup` runs them in one shot: `composer install`, `npm install`, `.env` copy, `key:generate`, `migrate`, `storage:link`.

README now presents two paths — automated first, manual as fallback — and keeps the separate-terminal instructions for `npm run dev` and `php artisan queue:work`.

## How to test

1. On a fresh clone, run `composer setup`.
2. Confirm `.env` exists, app key set, DB migrated, `storage` symlinked.
3. In separate terminals: `npm run dev`, `php artisan queue:work`, `php artisan serve`.
4. App loads at `http://localhost:8000`.