### PR TITLE
Fix thread composer autocomplete and notifications

### DIFF
--- a/app/Livewire/Questions/Create.php
+++ b/app/Livewire/Questions/Create.php
@@ -529,7 +529,14 @@ final class Create extends Component
             default => 'Question sent.'
         };
 
-        $this->dispatch('notification.created', message: $message);
+        if ($this->isSharingUpdate) {
+            $this->dispatch('notification.created', message: $message, url: route('questions.show', [
+                'username' => $question->to->username,
+                'question' => $question,
+            ]), actionText: 'View update');
+        } else {
+            $this->dispatch('notification.created', message: $message);
+        }
 
         if (filled($this->parentId)) {
             $this->js(<<<'JS'

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -43,16 +43,16 @@
     padding-right: 1rem;
 }
 
-.answer img,
-.answer figure,
+.answer > p img,
+.answer > p figure,
 .answer p > a:has(img) {
     @apply w-full rounded-xl overflow-hidden;
     display: block;
     margin-top: 0.35rem;
 }
 
-.answer img:first-child,
-.answer figure:first-child,
+.answer > p img:first-child,
+.answer > p figure:first-child,
 .answer p > a:has(img):first-child {
     margin-top: 0;
 }

--- a/resources/js/autocomplete.js
+++ b/resources/js/autocomplete.js
@@ -6,6 +6,9 @@ export const autocomplete = (config) => ({
     workingText: '',
     selectedIndex: 0,
     activeToken: false,
+    activeInputId: null,
+    pendingInput: null,
+    processingInput: false,
     listeners: [],
 
     init() {
@@ -14,17 +17,45 @@ export const autocomplete = (config) => ({
         this.initListeners();
     },
 
+    destroy() {
+        this.listeners.forEach((removeListener) => removeListener());
+    },
+
     initListeners() {
-        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputKeyup`, (payload) => {this.handleInput(payload)}));
-        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputArrowUp`, (event) => this.focusResultsUp()));
-        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputArrowDown`, (event) => this.focusResultsDown()));
-        this.listeners.push(Livewire.on(`${this.componentId}:selectAutocomplete`, (event) => this.select()));
-        this.listeners.push(Livewire.on(`${this.componentId}:closeAutocompletePanel`, (event) => this.closeResults()));
+        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputKeyup`, (payload) => this.handleInput(payload)));
+        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputArrowUp`, () => this.focusResultsUp()));
+        this.listeners.push(Livewire.on(`${this.componentId}:autocompleteBoundInputArrowDown`, () => this.focusResultsDown()));
+        this.listeners.push(Livewire.on(`${this.componentId}:selectAutocomplete`, () => this.select()));
+        this.listeners.push(Livewire.on(`${this.componentId}:closeAutocompletePanel`, () => this.closeResults()));
     },
 
     handleInput(payload) {
-        const cursorPosition = payload.event.target.selectionEnd || 0;
-        const activeToken = this.getActiveToken(payload.content, cursorPosition);
+        this.pendingInput = payload;
+
+        if (this.processingInput) {
+            return;
+        }
+
+        this.processPendingInput();
+    },
+
+    async processPendingInput() {
+        this.processingInput = true;
+
+        while (this.pendingInput !== null) {
+            const payload = this.pendingInput;
+            this.pendingInput = null;
+
+            await this.processInput(payload);
+        }
+
+        this.processingInput = false;
+    },
+
+    async processInput(payload) {
+        this.activeInputId = payload.inputId;
+
+        const activeToken = this.getActiveToken(payload.content, payload.cursorPosition);
 
         if (activeToken === undefined) {
             this.closeResults();
@@ -47,9 +78,9 @@ export const autocomplete = (config) => ({
             return;
         }
 
-        this.$wire.$call('setAutocompleteSearchParams', this.matchedTypes, activeToken.word);
-
         this.workingText = payload.content;
+
+        await this.$wire.$call('setAutocompleteSearchParams', this.matchedTypes, activeToken.word);
 
         this.openResults();
     },
@@ -82,8 +113,9 @@ export const autocomplete = (config) => ({
         replacement ??= this.getReplacementFromSelectedResult() ?? this.activeToken.word;
 
         Livewire.dispatch(`${this.componentId}:autocompleteSelected`, {
-            newValue: this.formatReplacement(replacement)
-        })
+            newValue: this.formatReplacement(replacement),
+            inputId: this.activeInputId,
+        });
 
         this.activeToken = false;
 
@@ -159,59 +191,68 @@ export const usesAutocomplete = (componentId) => ({
     listeners: [],
 
     init() {
-        Livewire.on(`${componentId}:autocompletePanelShown`, () => this.autocompletePanelIsShown = true);
-        Livewire.on(`${componentId}:autocompletePanelClosed`, () => this.autocompletePanelIsShown = false);
-        Livewire.on(`${componentId}:autocompleteSelected`, (event) => {
+        this.listeners.push(Livewire.on(`${componentId}:autocompletePanelShown`, () => this.autocompletePanelIsShown = true));
+        this.listeners.push(Livewire.on(`${componentId}:autocompletePanelClosed`, () => this.autocompletePanelIsShown = false));
+        this.listeners.push(Livewire.on(`${componentId}:autocompleteSelected`, (event) => {
+            if (event.inputId !== this.$el.id) {
+                return;
+            }
+
             this.$focus.focus(this.$el);
 
             this.$nextTick(() => {
                 this.$el.value = event.newValue;
                 this.$dispatch('input', event.newValue);
             });
-        })
+        }));
+    },
+
+    destroy() {
+        this.listeners.forEach((removeListener) => removeListener());
     },
 
     autocompleteInputBindings: {
-        ['@keyup.debounce.250ms'](event) {
+        ['@keyup.debounce.250ms']() {
             Livewire.dispatch(`${componentId}:autocompleteBoundInputKeyup`, {
                 content: this.$el.value,
-                event: event,
-            })
+                cursorPosition: this.$el.selectionEnd || 0,
+                inputId: this.$el.id,
+            });
         },
         ['@keydown.arrow-up'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch(`${componentId}:autocompleteBoundInputArrowUp`)
+                Livewire.dispatch(`${componentId}:autocompleteBoundInputArrowUp`);
             }
         },
         ['@keydown.arrow-down'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch(`${componentId}:autocompleteBoundInputArrowDown`)
+                Livewire.dispatch(`${componentId}:autocompleteBoundInputArrowDown`);
             }
         },
         ['@keydown.enter'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch(`${componentId}:selectAutocomplete`)
+                Livewire.dispatch(`${componentId}:selectAutocomplete`);
             }
         },
         ['@keydown.tab'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch(`${componentId}:selectAutocomplete`)
+                Livewire.dispatch(`${componentId}:selectAutocomplete`);
             }
         },
         ['@keydown.escape'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch(`${componentId}:closeAutocompletePanel`)
+                Livewire.dispatch(`${componentId}:closeAutocompletePanel`);
             }
         },
         ['@click.away'](event) {
             if (this.autocompletePanelIsShown) {
                 event.preventDefault();
-                Livewire.dispatch(`${componentId}:closeAutocompletePanel`)
+                Livewire.dispatch(`${componentId}:closeAutocompletePanel`);
             }
         },
     },

--- a/resources/views/components/autocomplete/hashtag-item.blade.php
+++ b/resources/views/components/autocomplete/hashtag-item.blade.php
@@ -1,4 +1,2 @@
-@php
-    /** @var \App\Services\Autocomplete\Result $result */
-@endphp
+@props(['result'])
 <span class="truncate text-sm font-medium text-slate-950 dark:text-slate-50"> {{ $result->replacement }} </span>

--- a/resources/views/components/autocomplete/mention-item.blade.php
+++ b/resources/views/components/autocomplete/mention-item.blade.php
@@ -1,6 +1,4 @@
-@php
-    /** @var \App\Services\Autocomplete\Result $result */
-@endphp
+@props(['result'])
 <div class="flex items-center justify-between">
     <div class="flex items-center gap-3">
         <figure class="{{ $result->payload['isCompanyVerified'] ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 dark:bg-slate-800 bg-slate-50">

--- a/resources/views/livewire/autocomplete.blade.php
+++ b/resources/views/livewire/autocomplete.blade.php
@@ -27,7 +27,11 @@
                         wire:key="{{ $result->id }}"
                         role="option"
                     >
-                        @include($result->view)
+                        @if ($result->view === 'components.autocomplete.mention-item')
+                            <x-autocomplete.mention-item :result="$result" />
+                        @elseif ($result->view === 'components.autocomplete.hashtag-item')
+                            <x-autocomplete.hashtag-item :result="$result" />
+                        @endif
                     </li>
                 @endif
             @empty

--- a/resources/views/livewire/flash-messages/show.blade.php
+++ b/resources/views/livewire/flash-messages/show.blade.php
@@ -1,20 +1,38 @@
 <div
     x-data="{
-        notify: function (message) {
+        notify: function (message, url, actionText) {
             this.$notify(message, {
                 wrapperId: 'flashMessageWrapper',
                 templateId: 'flashMessageTemplate',
-                autoClose: 3000,
-                autoRemove: 4000,
+                autoClose: url ? 6000 : 3000,
+                autoRemove: url ? 7000 : 4000,
             });
+
+            if (url && actionText) {
+                const notification = document.getElementById('flashMessageWrapper').lastElementChild;
+                const action = notification.querySelector('[data-notification-action]');
+
+                action.href = url;
+                action.textContent = actionText;
+                action.hidden = false;
+            }
         },
     }"
-    x-on:notification-created.dot.window="notify($event.detail.message)"
+    x-on:notification-created.dot.window="notify($event.detail.message, $event.detail.url, $event.detail.actionText)"
     @session('flash-message') x-init="notify('{{ $value }}')" @endsession
 >
     <div id="flashMessageWrapper" class="fixed top-4 right-4 z-50 w-64 space-y-2"></div>
 
     <template id="flashMessageTemplate">
-        <div role="alert" class="mt-12 rounded-lg bg-pink-500 px-4 py-3 text-white">{notificationText}</div>
+        <div role="alert" class="mt-12 rounded-lg bg-pink-500 px-4 py-3 text-white">
+            <span>{notificationText}</span>
+            <a
+                data-notification-action
+                hidden
+                class="ml-1 inline-flex items-center rounded px-1.5 py-0.5 text-sm font-semibold text-white underline decoration-white/60 underline-offset-2 transition hover:bg-white/15 hover:no-underline focus:ring-2 focus:ring-white/70 focus:outline-none"
+            >
+                View update
+            </a>
+        </div>
     </template>
 </div>

--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -1,5 +1,5 @@
 <div
-    class="{{ $this->customDraftKey === 'post_modal' ? 'flex min-h-0 flex-1 flex-col' : '' }}"
+    class="relative {{ $this->customDraftKey === 'post_modal' ? 'flex min-h-0 flex-1 flex-col' : '' }}"
     id="questions-create-{{ $this->getId() }}"
 >
     @php
@@ -43,6 +43,7 @@
                         <div class="min-w-0 flex-1 p-0">
                             <x-textarea
                                 x-model="content"
+                                id="mention-main-{{ $this->getId() }}"
                                 placeholder="{{ $this->placeholder }}"
                                 maxlength="{{ $this->maxContentLength }}"
                                 rows="1"
@@ -222,6 +223,9 @@
                                         <x-textarea
                                             x-model="threadPosts[index]"
                                             data-thread-post
+                                            ::id="`mention-thread-${index}-{{ $this->getId() }}`"
+                                            x-data="usesDynamicAutocomplete('mention-main-{{ $this->getId() }}')"
+                                            x-bind="autocompleteInputBindings"
                                             placeholder="Say more..."
                                             maxlength="{{ $this->maxContentLength }}"
                                             rows="1"

--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -273,7 +273,6 @@
                                         data-navigate-ignore="true"
                                         x-cloak
                                         x-data="copyUrl"
-                                        x-show="isVisible"
                                         x-on:click="
                                     copyToClipboard(
                                         '{{
@@ -285,6 +284,8 @@
                                     )
                                 "
                                         type="button"
+                                        aria-label="Copy link"
+                                        title="Copy link"
                                         class="{{ $shareMenuItemClasses }}"
                                     >
                                         <x-heroicon-o-link class="size-4" />

--- a/resources/views/livewire/questions/show.blade.php
+++ b/resources/views/livewire/questions/show.blade.php
@@ -288,7 +288,7 @@
                                         title="Copy link"
                                         class="{{ $shareMenuItemClasses }}"
                                     >
-                                        <x-heroicon-o-link class="size-4" />
+                                        <x-heroicon-o-clipboard-document class="size-4" />
                                     </button>
                                     <button
                                         data-navigate-ignore="true"
@@ -307,7 +307,7 @@
                                 "
                                         class="{{ $shareMenuItemClasses }}"
                                     >
-                                        <x-heroicon-o-link class="size-4" />
+                                        <x-heroicon-o-share class="size-4" />
                                     </button>
                                     <button
                                         data-navigate-ignore="true"

--- a/tests/Unit/Livewire/AutocompleteTest.php
+++ b/tests/Unit/Livewire/AutocompleteTest.php
@@ -82,6 +82,25 @@ test('autocompleteResults computed property returns correct data', function (): 
         ->and($result->first()->id)->toBe($user->id);
 });
 
+test('autocomplete renders all matching mention results', function (): void {
+    App\Models\User::factory()->create([
+        'username' => 'maria',
+        'name' => 'Maria',
+        'email_verified_at' => now(),
+    ]);
+    App\Models\User::factory()->create([
+        'username' => 'matt',
+        'name' => 'Matt',
+        'email_verified_at' => now(),
+    ]);
+
+    $component = Livewire::test(Autocomplete::class);
+    $component->set('matchedTypes', ['mentions']);
+    $component->set('query', 'ma');
+
+    $component->assertSeeInOrder(['Maria', 'Matt']);
+});
+
 test('autocompleteResults returns empty collection when no matched types are set', function (): void {
     $component = Livewire::test(Autocomplete::class);
 


### PR DESCRIPTION
Fixes: https://pinkary.com/@JonasCamitzRyden/questions/01a05407-7e0a-71c0-b513-b24ef3f8a8b2
The main issue was Livewire Blaze doing some optimization making dynamic render fail. it's quick patch now; maybe it will fix full later.

Also add a `View Update` button, since we can now post from anywhere.
<img width="354" height="147" alt="image" src="https://github.com/user-attachments/assets/27106b5d-3a2f-4cbd-a602-37015cf3da93" />

Also added a little copy link button to the share menu
<img width="149" height="179" alt="image" src="https://github.com/user-attachments/assets/28fe0fe2-48d2-456e-8d16-6e934646a5eb" />

