### PR TITLE
fix: round composer submit buttons for design consistency

### DIFF
--- a/resources/views/livewire/questions/create.blade.php
+++ b/resources/views/livewire/questions/create.blade.php
@@ -418,7 +418,7 @@
                     <button
                         type="submit"
                         :disabled="uploading"
-                        class="inline-flex items-center border border-{{ $user->left_color }} px-5 py-2.5 text-sm font-semibold text-{{ $user->left_color }} transition hover:bg-slate-950 hover:text-white disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-slate-800"
+                        class="inline-flex items-center rounded-md border border-{{ $user->left_color }} px-5 py-2.5 text-sm font-semibold text-{{ $user->left_color }} transition hover:bg-slate-950 hover:text-white disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-slate-800"
                     >
                         @if ($this->parentId)
                             {{ __('Reply') }}

--- a/resources/views/livewire/questions/edit.blade.php
+++ b/resources/views/livewire/questions/edit.blade.php
@@ -30,7 +30,7 @@
                 <div class="flex items-center gap-2">
                     <button
                         type="submit"
-                        class="inline-flex items-center border border-{{ $user->left_color }} px-5 py-2.5 text-sm font-semibold text-{{ $user->left_color }} transition hover:bg-slate-950 hover:text-white dark:hover:bg-slate-800"
+                        class="inline-flex items-center rounded-md border border-{{ $user->left_color }} px-5 py-2.5 text-sm font-semibold text-{{ $user->left_color }} transition hover:bg-slate-950 hover:text-white dark:hover:bg-slate-800"
                     >
                         {{ __('Send') }}
                     </button>


### PR DESCRIPTION
### What:

- [x] UI (visual) Bug Fix

### Description:

Adds `rounded-md` to the submit buttons in the question create and edit views, replacing square corners with rounded corners to match the application's existing button styling.

### Example

Post button:
<img width="1838" height="1364" alt="image" src="https://github.com/user-attachments/assets/28b665e4-3155-45b3-979e-961e847c43ff" />


Post reply:
<img width="2720" height="1526" alt="image" src="https://github.com/user-attachments/assets/1eee0277-e345-447b-81dd-ab9a2cb82efd" />

Post thread: 
<img width="1802" height="1210" alt="image" src="https://github.com/user-attachments/assets/c5ee4b6b-9b09-4955-b2ff-2eccd977bab8" />
