### PR TITLE
Reusable password input component Password toggle

### DIFF
--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -19,10 +19,9 @@
         <div>
             <x-input-label for="password" :value="__('Password')" class="text-slate-600 dark:text-slate-400" />
 
-            <x-text-input
+            <x-password-input
                 id="password"
                 class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
-                type="password"
                 name="password"
                 required
                 autocomplete="current-password"

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -25,26 +25,13 @@
         <div>
             <x-input-label for="password" :value="__('Password')" class="text-slate-600 dark:text-slate-400" />
 
-            <div class="relative" x-data="{ showPassword: false }">
-                <x-text-input
-                    id="password"
-                    class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 pr-10 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
-                    x-bind:type="showPassword ? 'text' : 'password'"
-                    name="password"
-                    required
-                    autocomplete="current-password"
-                />
-                <div class="absolute inset-y-0 right-0 flex items-center pr-3">
-                    <button
-                        type="button"
-                        x-on:click="showPassword = ! showPassword"
-                        class="rounded-md text-slate-400 transition hover:text-slate-600 focus:ring-4 focus:ring-pink-500/20 focus:outline-none dark:text-gray-500 dark:hover:text-gray-300"
-                    >
-                        <x-icons.eye x-show="showPassword" class="size-5" />
-                        <x-icons.eye-off x-show="! showPassword" class="size-5" />
-                    </button>
-                </div>
-            </div>
+            <x-password-input
+                id="password"
+                class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
+                name="password"
+                required
+                autocomplete="current-password"
+            />
 
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -61,14 +61,26 @@
         <div>
             <x-input-label for="password" :value="__('Password')" class="text-slate-600 dark:text-slate-400" />
 
-            <x-text-input
-                id="password"
-                class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
-                type="password"
-                name="password"
-                required
-                autocomplete="new-password"
-            />
+            <div class="relative" x-data="{ showPassword: false }">
+                <x-text-input
+                    id="password"
+                    class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 pr-14 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
+                    x-bind:type="showPassword ? 'text' : 'password'"
+                    name="password"
+                    required
+                    autocomplete="new-password"
+                />
+                <button
+                    type="button"
+                    x-on:click="showPassword = ! showPassword"
+                    x-bind:aria-label="showPassword ? 'Hide password' : 'Show password'"
+                    x-bind:aria-pressed="showPassword"
+                    class="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-4 focus-visible:ring-pink-500/20 dark:text-gray-500 dark:hover:text-gray-300"
+                >
+                    <x-icons.eye x-show="showPassword" class="size-5" />
+                    <x-icons.eye-off x-show="! showPassword" class="size-5" />
+                </button>
+            </div>
 
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
@@ -80,14 +92,26 @@
                 class="text-slate-600 dark:text-slate-400"
             />
 
-            <x-text-input
-                id="password_confirmation"
-                class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
-                type="password"
-                name="password_confirmation"
-                required
-                autocomplete="new-password"
-            />
+            <div class="relative" x-data="{ showPassword: false }">
+                <x-text-input
+                    id="password_confirmation"
+                    class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 pr-14 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
+                    x-bind:type="showPassword ? 'text' : 'password'"
+                    name="password_confirmation"
+                    required
+                    autocomplete="new-password"
+                />
+                <button
+                    type="button"
+                    x-on:click="showPassword = ! showPassword"
+                    x-bind:aria-label="showPassword ? 'Hide password confirmation' : 'Show password confirmation'"
+                    x-bind:aria-pressed="showPassword"
+                    class="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-4 focus-visible:ring-pink-500/20 dark:text-gray-500 dark:hover:text-gray-300"
+                >
+                    <x-icons.eye x-show="showPassword" class="size-5" />
+                    <x-icons.eye-off x-show="! showPassword" class="size-5" />
+                </button>
+            </div>
 
             <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
         </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -61,27 +61,13 @@
         <div>
             <x-input-label for="password" :value="__('Password')" class="text-slate-600 dark:text-slate-400" />
 
-            <div class="relative" x-data="{ showPassword: false }">
-                <x-text-input
-                    id="password"
-                    class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 pr-14 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
-                    type="password"
-                    x-bind:type="showPassword ? 'text' : 'password'"
-                    name="password"
-                    required
-                    autocomplete="new-password"
-                />
-                <button
-                    type="button"
-                    x-on:click="showPassword = ! showPassword"
-                    x-bind:aria-label="showPassword ? 'Hide password' : 'Show password'"
-                    x-bind:aria-pressed="showPassword"
-                    class="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-4 focus-visible:ring-pink-500/20 dark:text-gray-500 dark:hover:text-gray-300"
-                >
-                    <x-icons.eye x-cloak x-show="! showPassword" class="size-5" />
-                    <x-icons.eye-off x-cloak x-show="showPassword" class="size-5" />
-                </button>
-            </div>
+            <x-password-input
+                id="password"
+                class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
+                name="password"
+                required
+                autocomplete="new-password"
+            />
 
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
@@ -93,27 +79,14 @@
                 class="text-slate-600 dark:text-slate-400"
             />
 
-            <div class="relative" x-data="{ showPassword: false }">
-                <x-text-input
-                    id="password_confirmation"
-                    class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 pr-14 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
-                    type="password"
-                    x-bind:type="showPassword ? 'text' : 'password'"
-                    name="password_confirmation"
-                    required
-                    autocomplete="new-password"
-                />
-                <button
-                    type="button"
-                    x-on:click="showPassword = ! showPassword"
-                    x-bind:aria-label="showPassword ? 'Hide password confirmation' : 'Show password confirmation'"
-                    x-bind:aria-pressed="showPassword"
-                    class="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-4 focus-visible:ring-pink-500/20 dark:text-gray-500 dark:hover:text-gray-300"
-                >
-                    <x-icons.eye x-cloak x-show="! showPassword" class="size-5" />
-                    <x-icons.eye-off x-cloak x-show="showPassword" class="size-5" />
-                </button>
-            </div>
+            <x-password-input
+                id="password_confirmation"
+                :label="__('password confirmation')"
+                class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
+                name="password_confirmation"
+                required
+                autocomplete="new-password"
+            />
 
             <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
         </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -65,6 +65,7 @@
                 <x-text-input
                     id="password"
                     class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 pr-14 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
+                    type="password"
                     x-bind:type="showPassword ? 'text' : 'password'"
                     name="password"
                     required
@@ -77,8 +78,8 @@
                     x-bind:aria-pressed="showPassword"
                     class="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-4 focus-visible:ring-pink-500/20 dark:text-gray-500 dark:hover:text-gray-300"
                 >
-                    <x-icons.eye x-show="showPassword" class="size-5" />
-                    <x-icons.eye-off x-show="! showPassword" class="size-5" />
+                    <x-icons.eye x-cloak x-show="! showPassword" class="size-5" />
+                    <x-icons.eye-off x-cloak x-show="showPassword" class="size-5" />
                 </button>
             </div>
 
@@ -96,6 +97,7 @@
                 <x-text-input
                     id="password_confirmation"
                     class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 pr-14 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
+                    type="password"
                     x-bind:type="showPassword ? 'text' : 'password'"
                     name="password_confirmation"
                     required
@@ -108,8 +110,8 @@
                     x-bind:aria-pressed="showPassword"
                     class="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-4 focus-visible:ring-pink-500/20 dark:text-gray-500 dark:hover:text-gray-300"
                 >
-                    <x-icons.eye x-show="showPassword" class="size-5" />
-                    <x-icons.eye-off x-show="! showPassword" class="size-5" />
+                    <x-icons.eye x-cloak x-show="! showPassword" class="size-5" />
+                    <x-icons.eye-off x-cloak x-show="showPassword" class="size-5" />
                 </button>
             </div>
 

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -35,10 +35,9 @@
 
         <div>
             <x-input-label for="password" :value="__('Password')" class="text-slate-600 dark:text-slate-400" />
-            <x-text-input
+            <x-password-input
                 id="password"
                 class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
-                type="password"
                 name="password"
                 required
                 autocomplete="new-password"
@@ -53,10 +52,9 @@
                 class="text-slate-600 dark:text-slate-400"
             />
 
-            <x-text-input
+            <x-password-input
                 id="password_confirmation"
                 class="mt-2 block w-full rounded-md border-slate-200/80 bg-white px-3 py-2.5 text-sm text-slate-950 shadow-none placeholder:text-slate-400 focus:border-pink-500 focus:ring-4 focus:ring-pink-500/20 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-600"
-                type="password"
                 name="password_confirmation"
                 required
                 autocomplete="new-password"

--- a/resources/views/components/password-input.blade.php
+++ b/resources/views/components/password-input.blade.php
@@ -1,0 +1,20 @@
+@props(['disabled' => false, 'label' => __('password')])
+
+<div class="relative" x-data="{ showPassword: false }">
+    <x-text-input
+        type="password"
+        x-bind:type="showPassword ? 'text' : 'password'"
+        {{ $attributes->class('pr-10')->merge(['disabled' => $disabled]) }}
+    />
+
+    <button
+        type="button"
+        x-on:click="showPassword = ! showPassword"
+        x-bind:aria-label="showPassword ? 'Hide {{ $label }}' : 'Show {{ $label }}'"
+        x-bind:aria-pressed="showPassword"
+        class="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-4 focus-visible:ring-pink-500/20 dark:text-gray-500 dark:hover:text-gray-300"
+    >
+        <x-icons.eye x-cloak x-show="! showPassword" class="size-5" />
+        <x-icons.eye-off x-cloak x-show="showPassword" class="size-5" />
+    </button>
+</div>

--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -9,10 +9,9 @@
                 <div>
                     <x-input-label for="password" :value="__('Password')" />
 
-                    <x-text-input
+                    <x-password-input
                         id="password"
                         class="mt-1 block w-full"
-                        type="password"
                         name="password"
                         wire:model="password"
                         required

--- a/resources/views/profile/partials/delete-user-form.blade.php
+++ b/resources/views/profile/partials/delete-user-form.blade.php
@@ -27,10 +27,9 @@
             <div class="mt-6">
                 <x-input-label for="password" value="{{ __('Password') }}" class="sr-only" />
 
-                <x-text-input
+                <x-password-input
                     id="password"
                     name="password"
-                    type="password"
                     class="mt-1 block w-3/4"
                     placeholder="{{ __('Password') }}"
                 />

--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -13,10 +13,9 @@
 
         <div>
             <x-input-label for="update_password_current_password" :value="__('Current Password')" />
-            <x-text-input
+            <x-password-input
                 id="update_password_current_password"
                 name="current_password"
-                type="password"
                 class="mt-1 block w-full"
                 autocomplete="current-password"
             />
@@ -25,10 +24,9 @@
 
         <div>
             <x-input-label for="update_password_password" :value="__('New Password')" />
-            <x-text-input
+            <x-password-input
                 id="update_password_password"
                 name="password"
-                type="password"
                 class="mt-1 block w-full"
                 autocomplete="new-password"
             />
@@ -37,10 +35,9 @@
 
         <div>
             <x-input-label for="update_password_password_confirmation" :value="__('Confirm Password')" />
-            <x-text-input
+            <x-password-input
                 id="update_password_password_confirmation"
                 name="password_confirmation"
-                type="password"
                 class="mt-1 block w-full"
                 autocomplete="new-password"
             />


### PR DESCRIPTION
 ## Summary

  - Added a reusable `<x-password-input />` Blade component with a show/hide password toggle.
  - Replaced duplicated password input markup across authentication and profile forms.
  - Preserved existing labels, validation errors, autocomplete attributes, and Livewire
  bindings.

  ## Verification

  - `php artisan view:cache`
  - `php artisan test tests/Unit/Livewire/Auth/ConfirmPasswordTest.php`
  - Confirmed rendered password inputs are enabled and editable.