### PR TITLE
Disallow email aliases on registration and profile updates

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Jobs\UpdateUserAvatar;
 use App\Models\User;
+use App\Rules\NoEmailAlias;
 use App\Rules\NotBlockedAccount;
 use App\Rules\UnauthorizedEmailProviders;
 use App\Rules\Username;
@@ -39,7 +40,7 @@ final readonly class RegisteredUserController
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'username' => ['required', 'string', 'min:4', 'max:50', 'unique:'.User::class, new Username],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class, new UnauthorizedEmailProviders(), new NotBlockedAccount],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class, new NoEmailAlias(), new UnauthorizedEmailProviders(), new NotBlockedAccount],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
             'terms' => ['required', 'accepted'],
             'cf-turnstile-response' => app()->environment(['production', 'testing']) ? ['required', $turnstile] : [],

--- a/app/Http/Requests/UserUpdateRequest.php
+++ b/app/Http/Requests/UserUpdateRequest.php
@@ -8,6 +8,7 @@ use App\Enums\UserDefaultFeed;
 use App\Enums\UserMailPreference;
 use App\Models\User;
 use App\Rules\NoBlankCharacters;
+use App\Rules\NoEmailAlias;
 use App\Rules\UnauthorizedEmailProviders;
 use App\Rules\Username;
 use Illuminate\Container\Attributes\CurrentUser;
@@ -34,6 +35,7 @@ final class UserUpdateRequest extends FormRequest
             ],
             'email' => [
                 'required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->id),
+                new NoEmailAlias(),
                 new UnauthorizedEmailProviders(),
             ],
             'mail_preference_time' => [Rule::enum(UserMailPreference::class)],

--- a/app/Rules/NoEmailAlias.php
+++ b/app/Rules/NoEmailAlias.php
@@ -21,9 +21,9 @@ final readonly class NoEmailAlias implements ValidationRule
             return;
         }
 
-        $atPosition = mb_strrpos($value, '@');
+        $localPart = mb_strstr($value, '@', true);
 
-        if ($atPosition !== false && str_contains(mb_substr($value, 0, $atPosition), '+')) {
+        if ($localPart !== false && str_contains($localPart, '+')) {
             $fail('The :attribute cannot contain an email alias.');
         }
     }

--- a/app/Rules/NoEmailAlias.php
+++ b/app/Rules/NoEmailAlias.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+final readonly class NoEmailAlias implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value)) {
+            return;
+        }
+
+        $atPosition = mb_strrpos($value, '@');
+
+        if ($atPosition !== false && str_contains(mb_substr($value, 0, $atPosition), '+')) {
+            $fail('The :attribute cannot contain an email alias.');
+        }
+    }
+}

--- a/tests/Http/Profile/EditTest.php
+++ b/tests/Http/Profile/EditTest.php
@@ -489,3 +489,48 @@ test('user can re-fetch avatar from GitHub', function (): void {
         ->and($user->is_uploaded_avatar)->toBeFalse()
         ->and(session('flash-message'))->toBe('Updating avatar using GitHub.');
 });
+
+test('cannot update email to an email alias', function (): void {
+    $user = User::factory()->create([
+        'username' => 'myuser',
+        'email' => 'myemail@gmail.com',
+    ]);
+
+    $response = $this
+        ->actingAs($user)
+        ->patch('/profile', [
+            'name' => $user->name,
+            'username' => $user->username,
+            'email' => 'myemail+alias@gmail.com',
+            'mail_preference_time' => 'daily',
+            'prefers_anonymous_questions' => false,
+        ]);
+
+    $response
+        ->assertStatus(302)
+        ->assertSessionHasErrors([
+            'email' => 'The email cannot contain an email alias.',
+        ]);
+
+    expect($user->fresh()->email)->toBe('myemail@gmail.com');
+});
+
+test('user can update profile while keeping their email', function (): void {
+    $user = User::factory()->create([
+        'username' => 'myuser',
+        'email' => 'myemail@gmail.com',
+    ]);
+
+    $response = $this
+        ->actingAs($user)
+        ->patch('/profile', [
+            'name' => 'Updated Name',
+            'username' => $user->username,
+            'email' => 'myemail@gmail.com',
+            'mail_preference_time' => 'daily',
+            'prefers_anonymous_questions' => false,
+        ]);
+
+    $response->assertSessionHasNoErrors();
+    expect($user->fresh()->name)->toBe('Updated Name');
+});

--- a/tests/Http/Register/CreateTest.php
+++ b/tests/Http/Register/CreateTest.php
@@ -349,3 +349,28 @@ test('cannot register with blocked email', function (): void {
 
     $this->assertDatabaseMissing('users', ['email' => $email]);
 });
+
+test('cannot register with an email alias', function (string $email): void {
+    $response = $this->from('/register')->post('/register', [
+        'name' => 'Test User',
+        'username' => 'testuser',
+        'email' => $email,
+        'password' => 'password',
+        'password_confirmation' => 'password',
+        'terms' => true,
+    ]);
+
+    $response->assertRedirect('/register')
+        ->assertSessionHasErrors([
+            'email' => 'The email cannot contain an email alias.',
+        ]);
+
+    $this->assertDatabaseMissing('users', ['email' => $email]);
+})->with([
+    'username+new@gmail.com',
+    'username+alias@example.com',
+    'taylor+test@laravel.com',
+    'user.name+tag@example.co.uk',
+    '+user@example.com',
+    'user+@example.com',
+]);

--- a/tests/Unit/Rules/NoEmailAliasTest.php
+++ b/tests/Unit/Rules/NoEmailAliasTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Rules\NoEmailAlias;
+
+test('validation fails for emails containing aliases', function (string $email): void {
+    $rule = new NoEmailAlias;
+
+    $errorMessage = null;
+    $fail = function (string $message) use (&$errorMessage): void {
+        $errorMessage = $message;
+    };
+
+    $rule->validate('email', $email, $fail);
+
+    expect($errorMessage)->toBe('The :attribute cannot contain an email alias.');
+})->with([
+    'username+new@gmail.com',
+    'username+alias@example.com',
+    'taylor+test@laravel.com',
+    'user.name+tag@example.co.uk',
+    '+user@example.com',
+    'user+@example.com',
+]);
+
+test('validation passes for emails without aliases', function (string $email): void {
+    $rule = new NoEmailAlias;
+
+    $failed = false;
+    $fail = function () use (&$failed): void {
+        $failed = true;
+    };
+
+    $rule->validate('email', $email, $fail);
+
+    expect($failed)->toBeFalse();
+})->with([
+    'username@gmail.com',
+    'taylor@laravel.com',
+    'user.name@example.co.uk',
+    'admin@example.com',
+]);
+
+test('validation ignores non-string values', function (mixed $value): void {
+    $rule = new NoEmailAlias;
+
+    $failed = false;
+    $fail = function () use (&$failed): void {
+        $failed = true;
+    };
+
+    $rule->validate('email', $value, $fail);
+
+    expect($failed)->toBeFalse();
+})->with([
+    null,
+    123,
+    [['email' => 'test@example.com']],
+]);


### PR DESCRIPTION
Disallows email subaddressing / plus aliases (e.g. `username+new@gmail.com`) during registration and profile email updates.