### PR TITLE
feat: personalize verification email greeting

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,8 +7,10 @@ namespace App\Providers;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -29,6 +31,7 @@ final class AppServiceProvider extends ServiceProvider
         $this->configureModels();
         $this->configurePasswordValidation();
         $this->configureDates();
+        $this->configureEmailVerification();
         $this->configurePasswordResetUrl();
         $this->configureBlaze();
 
@@ -78,6 +81,23 @@ final class AppServiceProvider extends ServiceProvider
                 'token' => $token,
                 'email' => $notifiable->getEmailForPasswordReset(),
             ], absolute: false);
+        });
+    }
+
+    /**
+     * Personalize the verification email without changing Laravel's signed URL or expiry.
+     */
+    private function configureEmailVerification(): void
+    {
+        VerifyEmail::toMailUsing(function (mixed $notifiable, string $url): MailMessage {
+            $name = $notifiable instanceof User ? $notifiable->name : __('there');
+
+            return (new MailMessage)
+                ->subject(__('Verify your email address'))
+                ->greeting(__('Hello, :name!', ['name' => $name]))
+                ->line(__('Please click the button below to verify your email address.'))
+                ->action(__('Verify Email Address'), $url)
+                ->line(__('If you did not create an account, no further action is required.'));
         });
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -93,7 +93,7 @@ final class AppServiceProvider extends ServiceProvider
             $name = $notifiable instanceof User ? $notifiable->name : __('there');
 
             return (new MailMessage)
-                ->subject(__('Verify your email address'))
+                ->subject(__('Verify Email Address'))
                 ->greeting(__('Hello, :name!', ['name' => $name]))
                 ->line(__('Please click the button below to verify your email address.'))
                 ->action(__('Verify Email Address'), $url)

--- a/tests/Http/VerificationNotificationTest.php
+++ b/tests/Http/VerificationNotificationTest.php
@@ -17,7 +17,16 @@ test('sends verification notification', function (): void {
         ->post('email/verification-notification')
         ->assertRedirect('/');
 
-    Notification::assertSentTo($user, VerifyEmail::class);
+    Notification::assertSentTo(
+        $user,
+        VerifyEmail::class,
+        function (VerifyEmail $notification, array $channels) use ($user): bool {
+            expect($channels)->toBe(['mail'])
+                ->and($notification->toMail($user)->greeting)->toBe('Hello, '.$user->name.'!');
+
+            return true;
+        },
+    );
 });
 
 test('does not send verification notification if email is verified', function (): void {


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

Personalizes Laravel's email-verification notification with the recipient's name.

- Greets Pinkary users as `Hello, {name}!`.
- Preserves Laravel's signed verification URL, expiry, branded mail header, and delivery configuration.
- Covers both initial registration and verification-email resend flows.
- Adds a verification notification test for the personalized greeting.

### Testing:

- `composer test`
<img width="582" height="222" alt="image" src="https://github.com/user-attachments/assets/f016aec3-cabd-4710-a8f0-7f993d7dc9f9" />
