### PR TITLE
fix: align account deletion password toggle

### DIFF
--- a/resources/views/components/password-input.blade.php
+++ b/resources/views/components/password-input.blade.php
@@ -1,6 +1,6 @@
-@props(['disabled' => false, 'label' => __('password')])
+@props(['disabled' => false, 'label' => __('password'), 'wrapperClasses' => ''])
 
-<div class="relative" x-data="{ showPassword: false }">
+<div class="relative {{ $wrapperClasses }}" x-data="{ showPassword: false }">
     <x-text-input
         type="password"
         x-bind:type="showPassword ? 'text' : 'password'"

--- a/resources/views/profile/partials/delete-user-form.blade.php
+++ b/resources/views/profile/partials/delete-user-form.blade.php
@@ -30,7 +30,8 @@
                 <x-password-input
                     id="password"
                     name="password"
-                    class="mt-1 block w-3/4"
+                    wrapper-classes="w-3/4"
+                    class="mt-1 block w-full"
                     placeholder="{{ __('Password') }}"
                 />
 


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

Fixes the account-deletion modal's password visibility toggle, which was positioned outside the password field.

- Reuses the existing `<x-password-input />` component.
- Adds an optional wrapper class so a constrained-width password field retains its relative positioning.
- Keeps the delete-modal input at its existing width while placing the eye toggle inside the input's right edge.

### Testing:

- `composer test`