### PR TITLE
feat: add changelog navigation link

### DIFF
--- a/resources/views/components/changelog-link.blade.php
+++ b/resources/views/components/changelog-link.blade.php
@@ -1,0 +1,13 @@
+@props([
+    'classes' => '',
+    'dropdown' => false,
+])
+
+@if ($dropdown)
+    <x-dropdown-link :href="route('changelog')"> {{ __('Changelog') }} </x-dropdown-link>
+@else
+    <a title="Changelog" href="{{ route('changelog') }}" class="{{ $classes }}" wire:navigate>
+        <x-heroicon-o-document-text class="h-5 w-5" />
+        <span>{{ __('Changelog') }}</span>
+    </a>
+@endif

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -83,6 +83,8 @@
                         <x-heroicon-o-code-bracket class="h-5 w-5" />
                         <span>Source code</span>
                     </a>
+
+                    <x-changelog-link :classes="$desktopItemClasses.' '.$desktopIdleClasses" />
                 @else
                     <a
                         title="Feed"
@@ -113,6 +115,8 @@
                         <x-heroicon-o-code-bracket class="h-5 w-5" />
                         <span>Source code</span>
                     </a>
+
+                    <x-changelog-link :classes="$desktopItemClasses.' '.$desktopIdleClasses" />
 
                     <a
                         title="Log in"
@@ -378,6 +382,8 @@
                 >
                     {{ __('Source code') }}
                 </x-dropdown-link>
+
+                <x-changelog-link dropdown />
 
                 @auth
                     <x-dropdown-link :href="route('profile.edit')"> {{ __('Settings') }} </x-dropdown-link>

--- a/tests/Http/Home/FeedTest.php
+++ b/tests/Http/Home/FeedTest.php
@@ -17,6 +17,14 @@ it('can see the "feed" view', function (): void {
         ->assertSeeLivewire(Feed::class);
 });
 
+it('shows the changelog link to guests', function (): void {
+    $response = $this->get(route('home.feed'));
+
+    $response->assertOk()
+        ->assertSee('Changelog')
+        ->assertSee(route('changelog'));
+});
+
 it('can see the question create component when logged in with recent default feed', function (): void {
     $user = User::factory()->create(['default_feed' => UserDefaultFeed::Recent]);
 
@@ -25,6 +33,17 @@ it('can see the question create component when logged in with recent default fee
 
     $response->assertOk()
         ->assertSeeLivewire(Create::class);
+});
+
+it('shows the changelog link to authenticated users', function (): void {
+    $user = User::factory()->create(['default_feed' => UserDefaultFeed::Recent]);
+
+    $response = $this->actingAs($user)
+        ->get(route('home.feed'));
+
+    $response->assertOk()
+        ->assertSee('Changelog')
+        ->assertSee(route('changelog'));
 });
 
 it('redirects authenticated user with following default feed to the following page on fresh load', function (): void {


### PR DESCRIPTION
                                                                                     
  ### What:                                                                            
                                                                                       
  - [x] New Feature                                                                    
                                                                                       
  ### Description:                                                                     
                                                                                       
  Adds a reusable Changelog navigation link that routes to `/changelog`.               
                                                                                       
  The link appears directly below “Source code” in the desktop sidebar for both guests 
  and authenticated users, and in the mobile menu after “Source code”. Includes        
  coverage for guest and authenticated feed views. 
<img width="1281" height="626" alt="image" src="https://github.com/user-attachments/assets/2222e598-6637-4efa-96ee-fb781fe08fee" />
<img width="395" height="554" alt="image" src="https://github.com/user-attachments/assets/ee8ab0fb-4566-4fb0-8029-50f3ce50ad55" />
<img width="1301" height="609" alt="image" src="https://github.com/user-attachments/assets/5681b771-a3f2-4e1a-9831-d4f8451a3abd" />
