### PR TITLE
Make follow action idempotent

### DIFF
--- a/app/Actions/Users/CreateFollow.php
+++ b/app/Actions/Users/CreateFollow.php
@@ -13,6 +13,6 @@ final readonly class CreateFollow
      */
     public function handle(User $user, int $targetId): void
     {
-        $user->following()->attach($targetId);
+        $user->following()->syncWithoutDetaching($targetId);
     }
 }

--- a/tests/Unit/Livewire/Concerns/FollowableTest.php
+++ b/tests/Unit/Livewire/Concerns/FollowableTest.php
@@ -26,6 +26,19 @@ it('follows the given user', function (): void {
     );
 });
 
+it('does not fail when following the same user twice', function (): void {
+    $user = User::factory()->create();
+    $anotherUser = User::factory()->create();
+
+    /** @var Testable $component */
+    $component = Livewire::actingAs($user)->test(supportsFollow()::class);
+
+    $component->call('follow', $anotherUser->id);
+    $component->call('follow', $anotherUser->id);
+
+    expect($user->following()->whereKey($anotherUser->id)->count())->toBe(1);
+});
+
 it('unfollows the given user', function (): void {
     $user = User::factory()->create();
     $anotherUser = User::factory()->create();


### PR DESCRIPTION
Fixes Nightwatch #24, #10.Double follows (double-clicks, concurrent requests) crashed with a UNIQUE violation on followers; attach() is now syncWithoutDetaching() per the idempotent-write rule. Regression test double-calls follow and asserts a single row.Verified: affected suite 5 passed (fails on old code with the exact Nightwatch exception), phpstan clean, pint clean, rector clean.