### PR TITLE
Add mail suppression list with Filament management

### DIFF
--- a/app/Actions/Mail/RecordSuppressedEmail.php
+++ b/app/Actions/Mail/RecordSuppressedEmail.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Mail;
+
+use App\Models\SuppressedEmail;
+
+final readonly class RecordSuppressedEmail
+{
+    /**
+     * Record the email address as suppressed so future mails are skipped.
+     */
+    public function handle(string $email, ?string $reason = null): SuppressedEmail
+    {
+        return SuppressedEmail::query()->firstOrCreate(
+            ['email' => $email],
+            ['reason' => $reason],
+        );
+    }
+}

--- a/app/Console/Commands/SendUnreadNotificationEmailsCommand.php
+++ b/app/Console/Commands/SendUnreadNotificationEmailsCommand.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Enums\UserMailPreference;
 use App\Mail\PendingNotifications;
+use App\Models\SuppressedEmail;
 use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
@@ -40,6 +41,7 @@ final class SendUnreadNotificationEmailsCommand extends Command
                 $query->where('mail_preference_time', UserMailPreference::Daily);
             })
             ->whereHas('notifications')
+            ->whereNotIn('email', SuppressedEmail::query()->select('email'))
             ->withCount('notifications')
             ->each(fn (User $user) => Mail::to($user)->queue(new PendingNotifications($user, $user->notifications_count)));
     }

--- a/app/Filament/Resources/SuppressedEmailResource.php
+++ b/app/Filament/Resources/SuppressedEmailResource.php
@@ -45,6 +45,7 @@ final class SuppressedEmailResource extends Resource
                 Tables\Columns\TextColumn::make('email')
                     ->searchable()
                     ->copyable()
+                    ->copyableState(fn (string $state): string => $state)
                     ->formatStateUsing(function (string $state): string {
                         [$local, $domain] = array_pad(explode('@', $state, 2), 2, '');
                         $visible = mb_strlen($local) > 4 ? 2 : 1;

--- a/app/Filament/Resources/SuppressedEmailResource.php
+++ b/app/Filament/Resources/SuppressedEmailResource.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Actions\Users\DeleteUser;
+use App\Filament\Resources\SuppressedEmailResource\Pages;
+use App\Models\BlockedAccount;
+use App\Models\SuppressedEmail;
+use App\Models\User;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Resources\Resource;
+use Filament\Support\Colors\Color;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\DB;
+
+final class SuppressedEmailResource extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     */
+    protected static ?string $model = SuppressedEmail::class;
+
+    /**
+     * The navigation icon for the resource.
+     */
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-no-symbol';
+
+    /**
+     * Configures the table for the resource.
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('email')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('user.username')
+                    ->label('User'),
+                Tables\Columns\TextColumn::make('reason'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime(),
+            ])
+            ->actions([
+                Action::make('visit_profile')
+                    ->label('Visit Profile')
+                    ->url(fn (SuppressedEmail $record): ?string => $record->user instanceof User
+                        ? route('profile.show', ['username' => $record->user->username])
+                        : null)
+                    ->openUrlInNewTab(),
+
+                Action::make('delete_user')
+                    ->label('Delete User')
+                    ->requiresConfirmation()
+                    ->color(Color::Red)
+                    ->visible(fn (SuppressedEmail $record): bool => $record->user instanceof User)
+                    ->action(function (SuppressedEmail $record, DeleteUser $deleteUser): void {
+                        $user = $record->user;
+
+                        if (! $user instanceof User) {
+                            return;
+                        }
+
+                        DB::transaction(function () use ($record, $user, $deleteUser): void {
+                            BlockedAccount::firstOrCreate([
+                                'email' => $record->email,
+                            ]);
+
+                            $deleteUser->handle($user);
+                        });
+                    }),
+
+                Action::make('remove')
+                    ->label('Remove Suppression')
+                    ->requiresConfirmation()
+                    ->action(fn (SuppressedEmail $record): ?bool => $record->delete()),
+            ]);
+    }
+
+    /**
+     * Configures the pages for the resource.
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\Index::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SuppressedEmailResource.php
+++ b/app/Filament/Resources/SuppressedEmailResource.php
@@ -46,9 +46,10 @@ final class SuppressedEmailResource extends Resource
                     ->searchable()
                     ->copyable()
                     ->formatStateUsing(function (string $state): string {
-                        $visible = mb_strlen($state) > 8 ? 2 : 1;
+                        [$local, $domain] = array_pad(explode('@', $state, 2), 2, '');
+                        $visible = mb_strlen($local) > 4 ? 2 : 1;
 
-                        return Str::mask($state, '*', $visible, -$visible);
+                        return Str::mask($local, '*', $visible, -$visible).'@'.$domain;
                     }),
                 Tables\Columns\TextColumn::make('user.username')
                     ->label('User'),

--- a/app/Filament/Resources/SuppressedEmailResource.php
+++ b/app/Filament/Resources/SuppressedEmailResource.php
@@ -30,6 +30,11 @@ final class SuppressedEmailResource extends Resource
     protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-no-symbol';
 
     /**
+     * The navigation sort order for the resource.
+     */
+    protected static ?int $navigationSort = 100;
+
+    /**
      * Configures the table for the resource.
      */
     public static function table(Table $table): Table

--- a/app/Filament/Resources/SuppressedEmailResource.php
+++ b/app/Filament/Resources/SuppressedEmailResource.php
@@ -16,6 +16,7 @@ use Filament\Support\Colors\Color;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 final class SuppressedEmailResource extends Resource
 {
@@ -42,7 +43,13 @@ final class SuppressedEmailResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('email')
-                    ->searchable(),
+                    ->searchable()
+                    ->copyable()
+                    ->formatStateUsing(function (string $state): string {
+                        $visible = mb_strlen($state) > 8 ? 2 : 1;
+
+                        return Str::mask($state, '*', $visible, -$visible);
+                    }),
                 Tables\Columns\TextColumn::make('user.username')
                     ->label('User'),
                 Tables\Columns\TextColumn::make('reason'),

--- a/app/Filament/Resources/SuppressedEmailResource.php
+++ b/app/Filament/Resources/SuppressedEmailResource.php
@@ -47,9 +47,18 @@ final class SuppressedEmailResource extends Resource
             ->actions([
                 Action::make('visit_profile')
                     ->label('Visit Profile')
-                    ->url(fn (SuppressedEmail $record): ?string => $record->user instanceof User
-                        ? route('profile.show', ['username' => $record->user->username])
-                        : null)
+                    ->visible(fn (SuppressedEmail $record): bool => $record->user instanceof User)
+                    ->url(function (SuppressedEmail $record): string {
+                        $user = $record->user;
+
+                        if (! $user instanceof User) {
+                            return route('home.feed');
+                        }
+
+                        return route('profile.show', [
+                            'username' => $user->username,
+                        ]);
+                    })
                     ->openUrlInNewTab(),
 
                 Action::make('delete_user')

--- a/app/Filament/Resources/SuppressedEmailResource.php
+++ b/app/Filament/Resources/SuppressedEmailResource.php
@@ -62,17 +62,9 @@ final class SuppressedEmailResource extends Resource
                 Action::make('visit_profile')
                     ->label('Visit Profile')
                     ->visible(fn (SuppressedEmail $record): bool => $record->user instanceof User)
-                    ->url(function (SuppressedEmail $record): string {
-                        $user = $record->user;
-
-                        if (! $user instanceof User) {
-                            return route('home.feed');
-                        }
-
-                        return route('profile.show', [
-                            'username' => $user->username,
-                        ]);
-                    })
+                    ->url(fn (SuppressedEmail $record): string => route('profile.show', [
+                        'username' => $record->user()->firstOrFail()->username,
+                    ]))
                     ->openUrlInNewTab(),
 
                 Action::make('delete_user')
@@ -81,18 +73,12 @@ final class SuppressedEmailResource extends Resource
                     ->color(Color::Red)
                     ->visible(fn (SuppressedEmail $record): bool => $record->user instanceof User)
                     ->action(function (SuppressedEmail $record, DeleteUser $deleteUser): void {
-                        $user = $record->user;
-
-                        if (! $user instanceof User) {
-                            return;
-                        }
-
-                        DB::transaction(function () use ($record, $user, $deleteUser): void {
+                        DB::transaction(function () use ($record, $deleteUser): void {
                             BlockedAccount::firstOrCreate([
                                 'email' => $record->email,
                             ]);
 
-                            $deleteUser->handle($user);
+                            $deleteUser->handle($record->user()->firstOrFail());
                         });
                     }),
 

--- a/app/Filament/Resources/SuppressedEmailResource/Pages/Index.php
+++ b/app/Filament/Resources/SuppressedEmailResource/Pages/Index.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\SuppressedEmailResource\Pages;
+
+use App\Filament\Resources\SuppressedEmailResource;
+use Filament\Resources\Pages\ManageRecords;
+
+final class Index extends ManageRecords
+{
+    /**
+     * The resource class this page is for.
+     */
+    protected static string $resource = SuppressedEmailResource::class;
+}

--- a/app/Mail/PendingNotifications.php
+++ b/app/Mail/PendingNotifications.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
+use App\Actions\Mail\RecordSuppressedEmail;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -11,6 +12,9 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
+use Spatie\MailcoachMailer\Exceptions\EmailNotValid;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Throwable;
 
 final class PendingNotifications extends Mailable implements ShouldQueue
 {
@@ -49,6 +53,22 @@ final class PendingNotifications extends Mailable implements ShouldQueue
                 'pendingNotificationsCount' => $this->pendingNotificationsCount,
             ],
         );
+    }
+
+    /**
+     * Handle a permanent delivery failure by suppressing future mails.
+     */
+    public function failed(Throwable $throwable): void
+    {
+        $statusCode = $throwable instanceof EmailNotValid
+            ? 422
+            : ($throwable instanceof HttpTransportException ? $throwable->getResponse()->getStatusCode() : null);
+
+        if (! in_array($statusCode, [406, 422], true)) {
+            return;
+        }
+
+        app(RecordSuppressedEmail::class)->handle($this->user->email, "mailcoach-{$statusCode}");
     }
 
     /**

--- a/app/Models/SuppressedEmail.php
+++ b/app/Models/SuppressedEmail.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\SuppressedEmailFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property string $email
+ * @property string|null $reason
+ * @property \Carbon\CarbonImmutable|null $created_at
+ * @property \Carbon\CarbonImmutable|null $updated_at
+ * @property-read User|null $user
+ */
+final class SuppressedEmail extends Model
+{
+    /** @use HasFactory<SuppressedEmailFactory> */
+    use HasFactory;
+
+    /**
+     * The user currently holding the suppressed email address, if any.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'email', 'email');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/database/factories/SuppressedEmailFactory.php
+++ b/database/factories/SuppressedEmailFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\SuppressedEmail;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SuppressedEmail>
+ */
+final class SuppressedEmailFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'email' => $this->faker->unique()->safeEmail(),
+            'reason' => 'mailcoach-406',
+        ];
+    }
+}

--- a/database/migrations/2026_09_11_113901_create_suppressed_emails_table.php
+++ b/database/migrations/2026_09_11_113901_create_suppressed_emails_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('suppressed_emails', function (Blueprint $table): void {
+            $table->id();
+            $table->string('email')->unique();
+            $table->string('reason')->nullable();
+            $table->timestamps();
+        });
+    }
+};

--- a/tests/Arch/ModelsTest.php
+++ b/tests/Arch/ModelsTest.php
@@ -31,7 +31,7 @@ arch('models')
     ])->ignoring('App\Models\Concerns');
 
 arch('ensure factories', function (): void {
-    expect($models = getModels())->toHaveCount(11);
+    expect($models = getModels())->toHaveCount(12);
 
     foreach ($models as $model) {
         /* @var \Illuminate\Database\Eloquent\Factories\HasFactory $model */
@@ -41,7 +41,7 @@ arch('ensure factories', function (): void {
 });
 
 arch('ensure datetime casts', function (): void {
-    expect($models = getModels())->toHaveCount(11);
+    expect($models = getModels())->toHaveCount(12);
 
     foreach ($models as $model) {
         /* @var \Illuminate\Database\Eloquent\Factories\HasFactory $model */

--- a/tests/Console/SendReminderEmailsCommandTest.php
+++ b/tests/Console/SendReminderEmailsCommandTest.php
@@ -103,3 +103,36 @@ test('mails getting notification count', function (): void {
 
     Mail::assertQueued(PendingNotifications::class, fn (PendingNotifications $mail): bool => $mail->pendingNotificationsCount === 3);
 });
+
+test('skips suppressed emails', function (): void {
+    $suppressed = User::factory()->create([
+        'mail_preference_time' => UserMailPreference::Daily,
+    ]);
+
+    $recipient = User::factory()->create([
+        'mail_preference_time' => UserMailPreference::Daily,
+    ]);
+
+    $questioner = User::factory()->create([
+        'mail_preference_time' => UserMailPreference::Never,
+    ]);
+
+    foreach ([$suppressed, $recipient] as $user) {
+        $questioner->questionsSent()->create([
+            'to_id' => $user->id,
+            'content' => 'What is the meaning of life?',
+        ]);
+    }
+
+    App\Models\SuppressedEmail::factory()->create([
+        'email' => $suppressed->email,
+    ]);
+
+    Mail::fake();
+
+    $this->artisan(SendUnreadNotificationEmailsCommand::class)
+        ->assertExitCode(0);
+
+    Mail::assertQueued(PendingNotifications::class, 1);
+    Mail::assertQueued(PendingNotifications::class, fn (PendingNotifications $mail): bool => $mail->user->is($recipient));
+});

--- a/tests/Http/Citadel/SuppressedEmails/IndexTest.php
+++ b/tests/Http/Citadel/SuppressedEmails/IndexTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\SuppressedEmailResource;
+use App\Models\SuppressedEmail;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Livewire\Livewire;
+
+test('auth', function (): void {
+    $response = $this->get(SuppressedEmailResource::getUrl('index', isAbsolute: false));
+
+    $response->assertStatus(302)->assertRedirect(route('login'));
+});
+
+it('is only accessible to nuno', function (): void {
+    $user = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $response = $this->actingAs($user)->get(SuppressedEmailResource::getUrl('index', isAbsolute: false));
+
+    $response->assertStatus(200);
+});
+
+it('is not accessible to other users', function (): void {
+    $user = User::factory()->create([
+        'email' => 'nuno@laravel.com',
+    ]);
+
+    $response = $this->actingAs($user)->get(SuppressedEmailResource::getUrl('index', isAbsolute: false));
+
+    $response->assertStatus(403);
+});
+
+it('shows masked emails', function (): void {
+    $admin = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $this->actingAs($admin);
+
+    $record = SuppressedEmail::factory()->create([
+        'email' => 'jonathan@example.com',
+    ]);
+
+    Livewire::test(SuppressedEmailResource\Pages\Index::class)
+        ->assertCanSeeTableRecords([$record])
+        ->assertSee('jo****an@example.com');
+});
+
+it('shows profile and delete actions only when a user exists', function (): void {
+    $admin = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $this->actingAs($admin);
+
+    $user = User::factory()->create();
+
+    $withUser = SuppressedEmail::factory()->create([
+        'email' => $user->email,
+    ]);
+
+    $orphan = SuppressedEmail::factory()->create();
+
+    Livewire::test(SuppressedEmailResource\Pages\Index::class)
+        ->assertTableActionVisible('visit_profile', $withUser)
+        ->assertTableActionVisible('delete_user', $withUser)
+        ->assertTableActionHidden('visit_profile', $orphan)
+        ->assertTableActionHidden('delete_user', $orphan);
+});
+
+it('blocks the email when admin deletes the user', function (): void {
+    $admin = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $user = User::factory()->create();
+
+    $record = SuppressedEmail::factory()->create([
+        'email' => $user->email,
+    ]);
+
+    $this->actingAs($admin);
+
+    Livewire::test(SuppressedEmailResource\Pages\Index::class)
+        ->callAction(TestAction::make('delete_user')->table($record));
+
+    $this->assertDatabaseHas('blocked_accounts', ['email' => $user->email]);
+    expect($user->fresh())->toBeNull();
+});
+
+it('removes the suppression', function (): void {
+    $admin = User::factory()->create([
+        'email' => 'enunomaduro@gmail.com',
+    ]);
+
+    $record = SuppressedEmail::factory()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test(SuppressedEmailResource\Pages\Index::class)
+        ->callAction(TestAction::make('remove')->table($record));
+
+    $this->assertDatabaseMissing('suppressed_emails', ['id' => $record->id]);
+});

--- a/tests/Unit/Mail/PendingNotificationsTest.php
+++ b/tests/Unit/Mail/PendingNotificationsTest.php
@@ -9,6 +9,31 @@ use Spatie\MailcoachMailer\Exceptions\EmailNotValid;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 
+test('envelope', function (): void {
+    $user = User::factory()->create();
+
+    $mail = new PendingNotifications($user, 1);
+
+    $envelope = $mail->envelope();
+
+    expect($envelope->subject)
+        ->toBe('🌸 Pinkary: You Have 1 Notification! - '.now()->format('F j, Y'));
+});
+
+test('content', function (): void {
+    $user = User::factory()->create();
+
+    $mail = new PendingNotifications($user, 1);
+
+    foreach ([
+        '# Hello, '.$user->name.'!',
+        "We've noticed you have 1 notification. You can view notifications by clicking the button below.",
+        'If you no longer wish to receive these emails, you can change your "Mail Preference Time" in your [profile settings]('.config('app.url').'/profile).',
+    ] as $line) {
+        $mail->assertSeeInText($line);
+    }
+});
+
 test('records suppression on mailcoach rejection', function (): void {
     $user = User::factory()->create();
 

--- a/tests/Unit/Mail/PendingNotificationsTest.php
+++ b/tests/Unit/Mail/PendingNotificationsTest.php
@@ -3,29 +3,42 @@
 declare(strict_types=1);
 
 use App\Mail\PendingNotifications;
+use App\Models\SuppressedEmail;
 use App\Models\User;
+use Spatie\MailcoachMailer\Exceptions\EmailNotValid;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
 
-test('envelope', function (): void {
+test('records suppression on mailcoach rejection', function (): void {
     $user = User::factory()->create();
 
-    $mail = new PendingNotifications($user, 1);
+    $mail = new PendingNotifications($user, 3);
+    $mail->failed(new HttpTransportException(
+        'Unable to send an email (code 406).',
+        new MockResponse('{}', ['http_code' => 406])
+    ));
 
-    $envelope = $mail->envelope();
-
-    expect($envelope->subject)
-        ->toBe('🌸 Pinkary: You Have 1 Notification! - '.now()->format('F j, Y'));
+    expect(SuppressedEmail::query()->where('email', $user->email)->exists())->toBeTrue();
 });
 
-test('content', function (): void {
+test('records suppression on invalid email', function (): void {
     $user = User::factory()->create();
 
-    $mail = new PendingNotifications($user, 1);
+    $mail = new PendingNotifications($user, 3);
+    $mail->failed(EmailNotValid::make('invalid'));
 
-    foreach ([
-        '# Hello, '.$user->name.'!',
-        "We've noticed you have 1 notification. You can view notifications by clicking the button below.",
-        'If you no longer wish to receive these emails, you can change your "Mail Preference Time" in your [profile settings]('.config('app.url').'/profile).',
-    ] as $line) {
-        $mail->assertSeeInText($line);
-    }
+    expect(SuppressedEmail::query()->where('email', $user->email)->exists())->toBeTrue();
+});
+
+test('ignores transient failures', function (): void {
+    $user = User::factory()->create();
+
+    $mail = new PendingNotifications($user, 3);
+    $mail->failed(new HttpTransportException(
+        'Mailcoach server error.',
+        new MockResponse('{}', ['http_code' => 500])
+    ));
+    $mail->failed(new Exception('Connection lost.'));
+
+    expect(SuppressedEmail::query()->where('email', $user->email)->exists())->toBeFalse();
 });


### PR DESCRIPTION
Fixes Nightwatch #5 (and #20 same signature).Permanent Mailcoach rejections (406/422) for an address are now recorded in a suppressed_emails table via the mailable failed hook, and the digest command skips suppressed addresses. A Filament resource lists suppressions with the linked user, Visit Profile, Delete User (spam), and Remove Suppression actions.Verified: 7 tests pass (skip-suppressed command test, record-on-406/422 tests, ignore-transient test), phpstan clean, pint clean, rector clean.