### PR TITLE
feat: queue verification emails

### DIFF
--- a/app/Jobs/SendEmailVerification.php
+++ b/app/Jobs/SendEmailVerification.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+final class SendEmailVerification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(private readonly User $user) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $user = $this->user->fresh();
+
+        if ($user instanceof User && ! $user->hasVerifiedEmail()) {
+            $user->notify(new VerifyEmail);
+        }
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Contracts\Models\Viewable;
 use App\Enums\UserDefaultFeed;
 use App\Enums\UserMailPreference;
+use App\Jobs\SendEmailVerification;
 use App\Services\ParsableBio;
 use Carbon\CarbonImmutable;
 use Database\Factories\UserFactory;
@@ -90,6 +91,14 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
                 ->whereIn('id', $ids)
                 ->increment('views');
         });
+    }
+
+    /**
+     * Queue email verification so registration does not wait for mail delivery.
+     */
+    public function sendEmailVerificationNotification(): void
+    {
+        SendEmailVerification::dispatch($this);
     }
 
     /**

--- a/tests/Http/Profile/EditTest.php
+++ b/tests/Http/Profile/EditTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Jobs\SendEmailVerification;
 use App\Jobs\UpdateUserAvatar;
 use App\Models\User;
-use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
@@ -148,8 +148,8 @@ test('email verification status is unchanged when the email address is unchanged
     expect($user->refresh()->email_verified_at)->not->toBeNull();
 });
 
-test('email verification job sent & status reset when the email address is changed', function (): void {
-    Notification::fake();
+test('email verification job is queued and status resets when the email address is changed', function (): void {
+    Queue::fake();
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -163,7 +163,7 @@ test('email verification job sent & status reset when the email address is chang
 
     expect($user->email_verified_at)->toBeNull();
 
-    Notification::assertSentTo($user, VerifyEmail::class);
+    Queue::assertPushed(SendEmailVerification::class);
 });
 
 test('only updates avatar if email changes & avatar not been uploaded', function (): void {

--- a/tests/Http/VerificationNotificationTest.php
+++ b/tests/Http/VerificationNotificationTest.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Jobs\SendEmailVerification;
 use App\Models\User;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
 
-test('sends verification notification', function (): void {
-    Notification::fake();
+test('queues verification notification', function (): void {
+    Queue::fake();
 
     $user = User::factory()->create([
         'email_verified_at' => null,
@@ -16,6 +18,21 @@ test('sends verification notification', function (): void {
     $this->actingAs($user)
         ->post('email/verification-notification')
         ->assertRedirect('/');
+
+    Queue::assertPushed(
+        SendEmailVerification::class,
+        fn (SendEmailVerification $job): bool => true,
+    );
+});
+
+test('sends verification notification from the queue', function (): void {
+    Notification::fake();
+
+    $user = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    new SendEmailVerification($user)->handle();
 
     Notification::assertSentTo(
         $user,
@@ -30,7 +47,7 @@ test('sends verification notification', function (): void {
 });
 
 test('does not send verification notification if email is verified', function (): void {
-    Notification::fake();
+    Queue::fake();
 
     $user = User::factory()->create([
         'email_verified_at' => now(),
@@ -42,5 +59,5 @@ test('does not send verification notification if email is verified', function ()
             'username' => $user->username,
         ]));
 
-    Notification::assertNothingSent();
+    Queue::assertNothingPushed();
 });


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

Queues email-verification delivery so registration and email-change requests do not wait for SMTP.

- Adds a `SendEmailVerification` queued job that refreshes the user and skips delivery when the email has already been verified.
- Reuses Laravel's built-in `VerifyEmail` notification, preserving its signed verification URL and mail content.
- Routes the existing `sendEmailVerificationNotification()` extension point through the job, covering registration and verification-email resend requests.
- Updates profile and verification tests to assert the queued behavior.

### Testing:

- `vendor/bin/rector --dry-run`
- `vendor/bin/pint --test`
- Architecture, verification, and profile test suites: 40 passing tests / 189 assertions