### PR TITLE
style: refine home feed tabs

### DIFF
--- a/resources/views/components/home-menu.blade.php
+++ b/resources/views/components/home-menu.blade.php
@@ -7,12 +7,12 @@
 @endphp
 
 <div class="[&::-webkit-scrollbar]:hidden scrollbar-none overflow-x-auto [-ms-overflow-style:none]">
-    <div class="inline-flex min-w-full items-center gap-1 sm:min-w-0">
+    <div class="inline-flex min-w-full items-center gap-0.5 sm:min-w-0">
         @foreach ($tabs as $tab)
             <a
                 data-pan="home-tabs-{{ str($tab['label'])->lower() }}"
                 href="{{ route($tab['route']) }}"
-                class="{{ $tab['active'] ? 'bg-pink-500 px-3.5 py-1.5 text-white' : 'px-2 py-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-[#11192b] dark:hover:text-white' }} inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-semibold leading-4 transition duration-150 ease-in-out focus:outline-none"
+                class="{{ $tab['active'] ? 'bg-pink-500 px-3 py-1 text-white' : 'px-2.5 py-1 text-slate-500 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-400 dark:hover:bg-[#11192b] dark:hover:text-white' }} inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-semibold leading-4 transition duration-150 ease-in-out focus:outline-none"
                 title="{{ $tab['label'] }}"
                 wire:navigate
                 wire:transition


### PR DESCRIPTION
### What:
- [x] UI Improvement

### Description:
Refines the shared `x-home-menu` component used by the home feed tabs.

- Makes Recent, Following, and Trending fully rounded pills.
- Reduces tab padding and spacing for a more compact layout.
- Reuses the existing component, so the update is consistent across every page that uses these tabs.

### Testing:
- `vendor/bin/pint --test resources/views/components/home-menu.blade.php`
Before
<img width="2682" height="1280" alt="CleanShot 2026-09-12 at 2 10 10 AM@2x" src="https://github.com/user-attachments/assets/3a828552-6259-431d-986d-c436101ac24f" />
After
<img width="2718" height="1064" alt="CleanShot 2026-09-12 at 2 11 12 AM@2x" src="https://github.com/user-attachments/assets/a34cae5f-bba6-4c6a-bd74-a311ad9a513f" />
