### PR TITLE
Bound link preview requests and memoize repeated reads

### DIFF
--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -58,7 +58,7 @@ final readonly class MetaData
     public function fetch(): Collection
     {
         /** @var Collection<string, string> $cachedData */
-        $cachedData = Cache::remember(
+        $cachedData = Cache::memo()->remember(
             Str::of($this->url)->slug()->prepend('preview_')->value(),
             now()->addYear(),
             fn (): Collection => $this->getData()

--- a/app/Services/MetaData.php
+++ b/app/Services/MetaData.php
@@ -28,6 +28,11 @@ final readonly class MetaData
     public const int CARD_HEIGHT = 251;
 
     /**
+     * Timeout in seconds for the outbound requests made while rendering previews.
+     */
+    private const int HTTP_TIMEOUT_SECONDS = 3;
+
+    /**
      * The oEmbed endpoints keyed by their supported hosts.
      *
      * @var array<string, list<string>>
@@ -91,11 +96,19 @@ final readonly class MetaData
      */
     public function checkExistsAndSize(string $image): bool
     {
-        if (! (Http::head($image)->ok())) {
+        if (! (Http::timeout(self::HTTP_TIMEOUT_SECONDS)->head($image)->ok())) {
             return false;
         }
 
-        $dimensions = @getimagesize($image);
+        $previousTimeout = ini_get('default_socket_timeout');
+
+        ini_set('default_socket_timeout', (string) self::HTTP_TIMEOUT_SECONDS);
+
+        try {
+            $dimensions = @getimagesize($image);
+        } finally {
+            ini_set('default_socket_timeout', $previousTimeout);
+        }
         $min_width = self::CARD_WIDTH / 0.66;
         $min_height = self::CARD_HEIGHT / 0.66;
 
@@ -134,7 +147,7 @@ final readonly class MetaData
         $data = collect();
 
         try {
-            $response = Http::get($this->url);
+            $response = Http::timeout(self::HTTP_TIMEOUT_SECONDS)->get($this->url);
 
             if ($response->ok() && $response->body() !== '') {
                 $data = $this->parse(
@@ -160,7 +173,7 @@ final readonly class MetaData
         $data = collect();
 
         try {
-            $response = Http::get(
+            $response = Http::timeout(self::HTTP_TIMEOUT_SECONDS)->get(
                 url: $service.'?url='.urlencode($this->url).'&'.http_build_query($options)
             );
 
@@ -240,7 +253,7 @@ final readonly class MetaData
         }
 
         if ($data->has('site_name') && $data->get('site_name') === 'X (formerly Twitter)') {
-            $response = Http::withHeader('User-Agent', 'Twitterbot')->get($this->url);
+            $response = Http::withHeader('User-Agent', 'Twitterbot')->timeout(self::HTTP_TIMEOUT_SECONDS)->get($this->url);
 
             if ($response->ok() && $response->body() !== '') {
                 $data = $this->parseContent($response->body());

--- a/tests/Unit/Services/MetaDataTest.php
+++ b/tests/Unit/Services/MetaDataTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Exception\MalformedUriException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\HttpClientException;
+use Illuminate\Http\Client\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -296,4 +297,84 @@ it('handles empty content', function (): void {
     $data = $service->fetch();
 
     expect($data->isEmpty())->toBeTrue();
+});
+
+it('bounds page, image and twitter requests with a short timeout', function (): void {
+    $url = 'https://x.com/example/status/123';
+    $imagePath = storage_path('app/'.UploadedFile::fake()->image('timeout.jpg', 1000, 600)->store('images'));
+
+    $html = '
+        <html>
+            <head>
+                <meta property="og:site_name" content="X (formerly Twitter)">
+                <meta property="og:url" content="'.$url.'">
+                <meta property="og:image" content="'.$imagePath.'">
+            </head>
+        </html>
+    ';
+
+    /** @var array<int, mixed> $timeouts */
+    $timeouts = [];
+
+    Http::fake([
+        $url => function (Request $request, array $options) use (&$timeouts, $html): mixed {
+            $timeouts[] = $options['timeout'] ?? null;
+
+            return Http::response($html, 200);
+        },
+        '*' => function (Request $request, array $options) use (&$timeouts): mixed {
+            $timeouts[] = $options['timeout'] ?? null;
+
+            return Http::response(null, 200);
+        },
+    ]);
+    Http::preventStrayRequests();
+
+    $data = new MetaData($url)->fetch();
+
+    expect($data->get('image'))->toBe($imagePath)
+        ->and($timeouts)->not->toBeEmpty()
+        ->and($timeouts)->each->toBe(3);
+});
+
+it('bounds oembed requests with a short timeout', function (): void {
+    $url = 'https://youtu.be/dQw4w9WgXcQ';
+
+    /** @var array<int, mixed> $timeouts */
+    $timeouts = [];
+
+    Http::fake([
+        'www.youtube.com/oembed?url=*' => function (Request $request, array $options) use (&$timeouts): mixed {
+            $timeouts[] = $options['timeout'] ?? null;
+
+            return Http::response(['title' => 'Some video', 'type' => 'video'], 200);
+        },
+    ]);
+    Http::preventStrayRequests();
+
+    $data = new MetaData($url)->fetch();
+
+    expect($data->get('title'))->toBe('Some video')
+        ->and($timeouts)->not->toBeEmpty()
+        ->and($timeouts)->each->toBe(3);
+});
+
+it('restores the default socket timeout after checking image size', function (): void {
+    $imagePath = storage_path('app/'.UploadedFile::fake()->image('socket.jpg', 1000, 600)->store('images'));
+
+    Http::fake(['*' => Http::response(null, 200)]);
+    Http::preventStrayRequests();
+
+    $previous = ini_get('default_socket_timeout');
+    ini_set('default_socket_timeout', '123');
+
+    try {
+        $service = new MetaData('https://example.com');
+        $suitable = $service->checkExistsAndSize($imagePath);
+
+        expect($suitable)->toBeTrue()
+            ->and(ini_get('default_socket_timeout'))->toBe('123');
+    } finally {
+        ini_set('default_socket_timeout', $previous);
+    }
 });

--- a/tests/Unit/Services/MetaDataTest.php
+++ b/tests/Unit/Services/MetaDataTest.php
@@ -6,11 +6,14 @@ use App\Services\MetaData;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Exception\MalformedUriException;
+use Illuminate\Cache\Events\CacheHit;
+use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\HttpClientException;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 
@@ -377,4 +380,35 @@ it('restores the default socket timeout after checking image size', function ():
     } finally {
         ini_set('default_socket_timeout', $previous);
     }
+});
+
+it('serves repeated previews from memo with a single store hit', function (): void {
+    $url = 'https://example.com/memoized-preview';
+
+    Event::fake([
+        CacheHit::class,
+        CacheMissed::class,
+    ]);
+
+    Http::fake([
+        $url => Http::response('
+            <html>
+                <head>
+                    <meta property="og:title" content="Memoized preview">
+                </head>
+            </html>
+        ', 200),
+    ]);
+    Http::preventStrayRequests();
+
+    $first = new MetaData($url)->fetch();
+    $second = new MetaData($url)->fetch();
+    $third = new MetaData($url)->fetch();
+
+    expect($second->toArray())->toBe($first->toArray())
+        ->and($third->toArray())->toBe($first->toArray())
+        ->and($first->get('title'))->toBe('Memoized preview');
+
+    Event::assertDispatched(CacheMissed::class, 1);
+    Event::assertDispatched(CacheHit::class, 1);
 });


### PR DESCRIPTION
Link preview rendering did unbounded outbound HTTP on every cache miss and re-read the preview cache on every render. This bounds all four outbound calls at 3s (plus a socket-timeout guard around getimagesize) and serves repeated in-request preview reads from memo, with impact tests for both.