### PR TITLE
perf: lazily persist parsed question content

### DIFF
--- a/app/Actions/Questions/RefreshParsedContent.php
+++ b/app/Actions/Questions/RefreshParsedContent.php
@@ -19,6 +19,11 @@ final readonly class RefreshParsedContent
 
     /**
      * Get the parsed output for the field, refreshing the stored payload when stale.
+     *
+     * Read-repair: a miss parses both content and answer together so a
+     * stale row self-heals in a single UPDATE. This means reading one
+     * field can also pay the parse cost of the other, including its
+     * link-preview HTTP work, and may issue a write behind this read.
      */
     public function handle(Question $question, string $field, string $hashKey, string $value): string
     {

--- a/app/Actions/Questions/RefreshParsedContent.php
+++ b/app/Actions/Questions/RefreshParsedContent.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Questions;
+
+use App\Models\Question;
+use App\Services\ParsableContent;
+use JsonException;
+
+final readonly class RefreshParsedContent
+{
+    /**
+     * Create a new action instance.
+     */
+    public function __construct(
+        private ParsableContent $parsableContent,
+    ) {}
+
+    /**
+     * Get the parsed output for the field, refreshing the stored payload when stale.
+     */
+    public function handle(Question $question, string $field, string $hashKey, string $value): string
+    {
+        $stored = $this->stored($question, $field, $hashKey, $value);
+
+        if (is_string($stored)) {
+            return $stored;
+        }
+
+        $payload = $this->refresh($question);
+
+        return $payload[$field] ?? $this->parsableContent->parse($value);
+    }
+
+    /**
+     * Get the stored parsed output for the field, if it is fresh.
+     */
+    private function stored(Question $question, string $field, string $hashKey, string $value): ?string
+    {
+        $stored = $this->payload($question);
+
+        if (($stored['f'] ?? null) !== $this->parsableContent->fingerprint()) {
+            return null;
+        }
+
+        if (($stored[$hashKey] ?? null) !== sha1($value)) {
+            return null;
+        }
+
+        $html = $stored[$field] ?? null;
+
+        return is_string($html) ? $html : null;
+    }
+
+    /**
+     * Parse the raw fields and persist the fresh payload.
+     *
+     * @return array{c: string|null, a: string|null, content: string|null, answer: string|null, f: string}
+     */
+    private function refresh(Question $question): array
+    {
+        $attributes = $question->getAttributes();
+        $content = $attributes['content'] ?? null;
+        $answer = $attributes['answer'] ?? null;
+
+        $payload = [
+            'f' => $this->parsableContent->fingerprint(),
+            'c' => is_string($content) ? sha1($content) : null,
+            'a' => is_string($answer) ? sha1($answer) : null,
+            'content' => $this->parseRaw($content),
+            'answer' => $this->parseRaw($answer),
+        ];
+
+        if ($question->exists && ! $question->isDirty(['content', 'answer'])) {
+            $json = json_encode($payload, JSON_THROW_ON_ERROR);
+
+            $question->newQuery()->whereKey($question->getKey())->update(['parsed' => $json]);
+            $question->setRawAttributes(array_merge($attributes, ['parsed' => $json]), true);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Parse a raw value using the empty value semantics of the accessors.
+     */
+    private function parseRaw(mixed $value): ?string
+    {
+        if (! is_string($value) || in_array($value, ['', '0'], true)) {
+            return null;
+        }
+
+        return $this->parsableContent->parse($value);
+    }
+
+    /**
+     * Decode the stored parsed payload, tolerating legacy or corrupt values.
+     *
+     * @return array<string, mixed>
+     */
+    private function payload(Question $question): array
+    {
+        $raw = $question->getAttributes()['parsed'] ?? null;
+
+        if (! is_string($raw) || $raw === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return [];
+        }
+
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Actions\Questions\RefreshParsedContent;
 use App\Contracts\Models\Viewable;
 use App\Models\Scopes\WhereNotModerated;
 use App\Observers\QuestionObserver;
-use App\Services\ParsableContent;
 use Carbon\CarbonImmutable;
 use Database\Factories\QuestionFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
  * @property int $to_id
  * @property bool $pinned
  * @property string $content
+ * @property string|null $parsed
  * @property bool $anonymously
  * @property string|null $answer
  * @property CarbonImmutable|null $answer_created_at
@@ -57,6 +58,13 @@ final class Question extends Model implements Viewable
     use HasFactory, HasUuids;
 
     /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = ['parsed'];
+
+    /**
      * Increment the views for the given question IDs.
      */
     public static function incrementViews(array $ids): void
@@ -74,9 +82,11 @@ final class Question extends Model implements Viewable
      */
     public function getContentAttribute(?string $value): ?string
     {
-        $content = new ParsableContent();
+        if (in_array($value, [null, '', '0'], true)) {
+            return null;
+        }
 
-        return in_array($value, [null, '', '0'], true) ? null : $content->parse($value);
+        return app(RefreshParsedContent::class)->handle($this, 'content', 'c', $value);
     }
 
     /**
@@ -84,9 +94,11 @@ final class Question extends Model implements Viewable
      */
     public function getAnswerAttribute(?string $value): ?string
     {
-        $content = new ParsableContent();
+        if (in_array($value, [null, '', '0'], true)) {
+            return null;
+        }
 
-        return in_array($value, [null, '', '0'], true) ? null : $content->parse($value);
+        return app(RefreshParsedContent::class)->handle($this, 'answer', 'a', $value);
     }
 
     /**

--- a/app/Services/ParsableContent.php
+++ b/app/Services/ParsableContent.php
@@ -12,15 +12,19 @@ use App\Services\ParsableContentProviders\ImageProviderParsable;
 use App\Services\ParsableContentProviders\LinkProviderParsable;
 use App\Services\ParsableContentProviders\MentionProviderParsable;
 use App\Services\ParsableContentProviders\StripProviderParsable;
+use ReflectionClass;
 
-final readonly class ParsableContent
+final class ParsableContent
 {
+    /** @var array<string, string> */
+    private static array $fingerprints = [];
+
     /**
      * Creates a new parsable content instance.
      *
      * @param  array<int, class-string<ParsableContentProvider>>  $providers
      */
-    public function __construct(private array $providers = [
+    public function __construct(private readonly array $providers = [
         StripProviderParsable::class,
         CodeProviderParsable::class,
         ImageProviderParsable::class,
@@ -44,5 +48,42 @@ final readonly class ParsableContent
 
                 return $provider->parse($parsed);
             }, $content);
+    }
+
+    /**
+     * Fingerprint of the parser pipeline.
+     *
+     * Derived from the source of every provider, the link metadata
+     * parsing, and the preview card markup, so any rendering change
+     * automatically stale-marks previously stored parses.
+     */
+    public function fingerprint(): string
+    {
+        $key = implode(',', $this->providers);
+
+        if (! isset(self::$fingerprints[$key])) {
+            $hashes = [];
+
+            /** @var list<class-string> $classes */
+            $classes = [...$this->providers, MetaData::class];
+
+            foreach ($classes as $class) {
+                $file = new ReflectionClass($class)->getFileName();
+
+                if (is_string($file)) {
+                    $hashes[] = md5_file($file);
+                }
+            }
+
+            $blade = md5_file(resource_path('views/components/link-preview-card.blade.php'));
+
+            if (is_string($blade)) {
+                $hashes[] = $blade;
+            }
+
+            self::$fingerprints[$key] = sha1((string) json_encode($hashes));
+        }
+
+        return self::$fingerprints[$key];
     }
 }

--- a/app/Services/ParsableContent.php
+++ b/app/Services/ParsableContent.php
@@ -53,9 +53,10 @@ final class ParsableContent
     /**
      * Fingerprint of the parser pipeline.
      *
-     * Derived from the source of every provider, the link metadata
-     * parsing, and the preview card markup, so any rendering change
-     * automatically stale-marks previously stored parses.
+     * Derived from the source of every provider, the orchestration
+     * itself, the link metadata parsing, and the preview card markup,
+     * so any rendering change automatically stale-marks previously
+     * stored parses.
      */
     public function fingerprint(): string
     {
@@ -65,7 +66,7 @@ final class ParsableContent
             $hashes = [];
 
             /** @var list<class-string> $classes */
-            $classes = [...$this->providers, MetaData::class];
+            $classes = [...$this->providers, MetaData::class, self::class];
 
             foreach ($classes as $class) {
                 $file = new ReflectionClass($class)->getFileName();

--- a/database/migrations/2026_09_12_064521_add_parsed_payload_columns.php
+++ b/database/migrations/2026_09_12_064521_add_parsed_payload_columns.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('questions', function (Blueprint $table): void {
+            $table->text('parsed')->nullable();
+        });
+    }
+};

--- a/tests/Unit/Models/QuestionTest.php
+++ b/tests/Unit/Models/QuestionTest.php
@@ -8,6 +8,9 @@ use App\Models\Like;
 use App\Models\PollOption;
 use App\Models\Question;
 use App\Models\User;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 test('to array', function (): void {
     $question = Question::factory()->create()->fresh();
@@ -176,4 +179,65 @@ test('get sharable text', function (): void {
         ->and($question->getSharableText('Hello <pre><code>Code</code></pre>'))->toBe('Hello  [👀 see the code on Pinkary 👀] ')
         ->and($question->getSharableText('Hello<br>World'))->toBe('Hello World')
         ->and($question->getSharableText('hello<div id="link-preview-card">Preview</div>'))->toBe('hello');
+});
+
+test('writes back the parse once and serves it afterwards', function (): void {
+    $question = Question::factory()->create([
+        'content' => 'Hello #pinkary!',
+        'answer' => 'Hi @johndoe!',
+    ]);
+
+    $updates = 0;
+
+    DB::listen(function (QueryExecuted $query) use (&$updates): void {
+        if (Str::startsWith($query->sql, 'update')) {
+            $updates++;
+        }
+    });
+
+    $first = $question->content;
+
+    expect($first)->toContain('/hashtag/pinkary')
+        ->and($question->answer)->toContain('@johndoe')
+        ->and($updates)->toBe(1);
+
+    $fresh = $question->fresh();
+
+    expect($fresh->content)->toBe($first)
+        ->and($updates)->toBe(1)
+        ->and($fresh->getAttributes()['parsed'])->not->toBeNull();
+});
+
+test('repairs stale parses', function (): void {
+    $question = Question::factory()->create([
+        'content' => 'Hello #pinkary!',
+    ]);
+
+    Question::query()->whereKey($question->getKey())->update(['parsed' => '{"f":"stale"}']);
+
+    expect($question->fresh()->content)->toContain('/hashtag/pinkary')
+        ->and($question->fresh()->getAttributes()['parsed'])->not->toBe('{"f":"stale"}');
+});
+
+test('repairs corrupt parses', function (): void {
+    $question = Question::factory()->create([
+        'content' => 'Hello #pinkary!',
+    ]);
+
+    Question::query()->whereKey($question->getKey())->update(['parsed' => 'not-json{{{']);
+
+    expect($question->fresh()->content)->toContain('/hashtag/pinkary');
+});
+
+test('does not persist parses for unsaved changes', function (): void {
+    $question = Question::factory()->create([
+        'content' => 'Hello #pinkary!',
+    ]);
+
+    expect($question->getAttributes()['parsed'])->toBeNull();
+
+    $question->content = 'Hello #laravel!';
+
+    expect($question->content)->toContain('/hashtag/laravel')
+        ->and($question->getAttributes()['parsed'])->toBeNull();
 });


### PR DESCRIPTION
Lazily materializes parsed question content/answer into a nullable questions.parsed JSON payload (fingerprint + per-field sha1), served on repeat reads and self-healed when stale or corrupt. Write-back is a single timestamp-safe query-builder UPDATE, skipped for unsaved/dirty models.

- Adds ParsableContent::fingerprint() (provider + MetaData + preview-card hashes, process-memoized) so renderer changes auto-stale old rows
- Slim Question accessors delegate to new App\Actions\Questions\RefreshParsedContent action; parsed column hidden from serialization
- No backfill, no submit latency by construction

Verification:
- 4 new impact tests in tests/Unit/Models/QuestionTest.php (write-once-then-serve, stale repair, corrupt repair, no-persist-on-dirty); fail-before proven
- Benchmark (20 questions x content+answer x 10 passes, HTTP faked): stored ~20-40ms vs live ~600-700ms (~17-30x)
- phpstan, pint, rector, type-coverage 100% clean; 268 broad tests green