### PR TITLE
feat: admin-only channel slugs

### DIFF
--- a/app/Livewire/Concerns/HasChannelPicker.php
+++ b/app/Livewire/Concerns/HasChannelPicker.php
@@ -49,7 +49,7 @@ trait HasChannelPicker
     #[Computed]
     public function availableChannels(): Collection
     {
-        return Cache::remember(
+        $channels = Cache::remember(
             'channels:popular',
             3600,
             fn (): Collection => Channel::query()
@@ -58,6 +58,12 @@ trait HasChannelPicker
                 ->limit(8)
                 ->get(),
         );
+
+        if ($this->isCurrentUserAdmin()) {
+            return $channels;
+        }
+
+        return $channels->reject(fn (Channel $channel): bool => $channel->isAdminOnly())->values();
     }
 
     /**
@@ -76,11 +82,17 @@ trait HasChannelPicker
             ])->values()->all();
         }
 
-        return Channel::query()
+        $channelQuery = Channel::query()
             ->where('name', 'like', "%{$q}%")
             ->orderByDesc('questions_count')
             ->orderBy('name')
-            ->limit(8)
+            ->limit(8);
+
+        if (! $this->isCurrentUserAdmin()) {
+            $channelQuery->whereNotIn('slug', Channel::ADMIN_ONLY_SLUGS);
+        }
+
+        return $channelQuery
             ->get()
             ->map(fn (Channel $channel): array => [
                 'id' => $channel->id,
@@ -149,6 +161,10 @@ trait HasChannelPicker
             return null;
         }
 
+        if (in_array($slug, Channel::ADMIN_ONLY_SLUGS, true) && ! $this->isCurrentUserAdmin()) {
+            return null;
+        }
+
         $channel = Channel::where('slug', $slug)->first();
 
         if ($channel) {
@@ -201,19 +217,39 @@ trait HasChannelPicker
                 return false;
             }
 
+            if (in_array($slug, Channel::ADMIN_ONLY_SLUGS, true) && ! $user->isAdmin()) {
+                return null;
+            }
+
             return $createChannel->handle($user, $channelName, $slug)->id;
         }
 
         if ($this->channelId !== null) {
-            if (Channel::whereKey($this->channelId)->exists()) {
-                return $this->channelId;
+            $slug = Channel::whereKey($this->channelId)->value('slug');
+
+            if (! is_string($slug)) {
+                $this->addError('channelId', 'Selected channel does not exist.');
+
+                return false;
             }
 
-            $this->addError('channelId', 'Selected channel does not exist.');
+            if (in_array($slug, Channel::ADMIN_ONLY_SLUGS, true) && ! $user->isAdmin()) {
+                return null;
+            }
 
-            return false;
+            return $this->channelId;
         }
 
         return null;
+    }
+
+    /**
+     * Determine if the current user is an admin.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        $user = auth()->user();
+
+        return $user instanceof User && $user->isAdmin();
     }
 }

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -30,6 +30,15 @@ final class Channel extends Model
     use HasFactory;
 
     /**
+     * Slugs only admins may create channels for or post to.
+     *
+     * @var list<string>
+     */
+    public const array ADMIN_ONLY_SLUGS = [
+        'announcements',
+    ];
+
+    /**
      * Get the route key for the model.
      */
     public function getRouteKeyName(): string
@@ -43,6 +52,14 @@ final class Channel extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Determine if the channel is restricted to admins.
+     */
+    public function isAdminOnly(): bool
+    {
+        return in_array($this->slug, self::ADMIN_ONLY_SLUGS, true);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -93,11 +93,19 @@ final class User extends Authenticatable implements FilamentUser, MustVerifyEmai
     }
 
     /**
+     * Determine if the user is an admin.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->email === 'enunomaduro@gmail.com' || $this->email === 'mrpunyapal@gmail.com';
+    }
+
+    /**
      * Determine if the user can access the admin given panel.
      */
     public function canAccessPanel(Panel $panel): bool
     {
-        return $this->hasVerifiedEmail() && ($this->email === 'enunomaduro@gmail.com' || $this->email === 'mrpunyapal@gmail.com');
+        return $this->hasVerifiedEmail() && $this->isAdmin();
     }
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -59,4 +59,14 @@ final class UserFactory extends Factory
             'email_verified_at' => null,
         ]);
     }
+
+    /**
+     * Indicate that the user is an admin.
+     */
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'email' => 'enunomaduro@gmail.com',
+        ]);
+    }
 }

--- a/tests/Http/PostChannelTest.php
+++ b/tests/Http/PostChannelTest.php
@@ -385,3 +385,88 @@ it('validates channelName tampering and non-existent channelId on update', funct
         ->call('update')
         ->assertHasErrors(['channelId']);
 });
+
+it('hides admin-only channels from the dropdown for non-admins', function (): void {
+    $user = User::factory()->create();
+    Channel::factory()->create(['name' => 'Announcements', 'slug' => 'announcements']);
+    Channel::factory()->create(['name' => 'Laravel', 'slug' => 'laravel']);
+
+    $component = Livewire::actingAs($user)->test(Create::class, ['toId' => $user->id]);
+
+    expect($component->instance()->availableChannels->pluck('slug')->all())
+        ->not->toContain('announcements')
+        ->toContain('laravel');
+});
+
+it('shows admin-only channels in the dropdown for admins', function (): void {
+    $admin = User::factory()->admin()->create();
+    Channel::factory()->create(['name' => 'Announcements', 'slug' => 'announcements']);
+
+    $component = Livewire::actingAs($admin)->test(Create::class, ['toId' => $admin->id]);
+
+    expect($component->instance()->availableChannels->pluck('slug')->all())
+        ->toContain('announcements');
+});
+
+it('excludes admin-only channels from search for non-admins', function (): void {
+    $user = User::factory()->create();
+    Channel::factory()->create(['name' => 'Announcements', 'slug' => 'announcements']);
+
+    $component = Livewire::actingAs($user)->test(Create::class, ['toId' => $user->id]);
+
+    expect($component->instance()->searchChannels('Announce'))->toBeEmpty();
+});
+
+it('silently ignores admin-only channel names for non-admins', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Create::class, ['toId' => $user->id])
+        ->call('createChannel', 'Announcements')
+        ->assertHasNoErrors()
+        ->assertSet('channelName', null);
+
+    expect(Channel::where('slug', 'announcements')->exists())->toBeFalse();
+});
+
+it('strips the admin-only channel when non-admins post', function (): void {
+    $user = User::factory()->create();
+    $channel = Channel::factory()->create(['name' => 'Announcements', 'slug' => 'announcements']);
+
+    Livewire::actingAs($user)
+        ->test(Create::class, ['toId' => $user->id])
+        ->set('content', 'Posting past announcements')
+        ->set('channelId', $channel->id)
+        ->call('store')
+        ->assertHasNoErrors();
+
+    expect(Question::where('answer', 'Posting past announcements')->first()?->channel_id)->toBeNull();
+});
+
+it('strips admin-only channel names claimed via channel name', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Create::class, ['toId' => $user->id])
+        ->set('content', 'Claiming announcements quietly')
+        ->set('channelName', 'Announcements')
+        ->call('store')
+        ->assertHasNoErrors();
+
+    expect(Channel::where('slug', 'announcements')->exists())->toBeFalse()
+        ->and(Question::where('answer', 'Claiming announcements quietly')->first()?->channel_id)->toBeNull();
+});
+
+it('allows admins to post to an admin-only channel', function (): void {
+    $admin = User::factory()->admin()->create();
+    $channel = Channel::factory()->create(['name' => 'Announcements', 'slug' => 'announcements', 'questions_count' => 0]);
+
+    Livewire::actingAs($admin)
+        ->test(Create::class, ['toId' => $admin->id])
+        ->set('content', 'Admin announcement')
+        ->set('channelId', $channel->id)
+        ->call('store')
+        ->assertHasNoErrors();
+
+    expect(Question::where('answer', 'Admin announcement')->first()?->channel_id)->toBe($channel->id);
+});


### PR DESCRIPTION
Restricts reserved channel slugs (starting with announcements) to admins.

- Non-admins: slug hidden from channel dropdown and search; create/post attempts silently skip the channel instead of erroring.
- Admins: unchanged, full access.
- Adds User::isAdmin reused by the panel gate, Channel::ADMIN_ONLY_SLUGS + isAdminOnly, UserFactory admin state.
- Tests: 7 new cases in PostChannelTest (fail-before verified).