### PR TITLE
fix: ignore non-string autocomplete types

### DIFF
--- a/app/Livewire/Autocomplete.php
+++ b/app/Livewire/Autocomplete.php
@@ -69,7 +69,9 @@ final class Autocomplete extends Component
      */
     public function setAutocompleteSearchParams(array $matchedTypes, string $query): void
     {
-        $this->matchedTypes = array_intersect($matchedTypes, array_keys($this->autocompleteTypes));
+        $matchedTypes = array_filter($matchedTypes, is_string(...));
+
+        $this->matchedTypes = array_values(array_intersect($matchedTypes, array_keys($this->autocompleteTypes)));
         $this->query = $this->matchedTypes === [] ? '' : $query;
     }
 
@@ -87,6 +89,8 @@ final class Autocomplete extends Component
         // $matchedTypes is public, so a tampered Livewire payload can bypass setAutocompleteSearchParams().
         // @phpstan-ignore-next-line
         return collect($this->matchedTypes)
+            // @phpstan-ignore-next-line
+            ->filter(fn (mixed $value): bool => is_string($value))
             ->intersect(array_keys($knownTypes))
             ->map(fn (string $typeAlias): Collection => $this->autocompleteService
                 ->search($typeAlias, $this->query)

--- a/tests/Unit/Livewire/AutocompleteTest.php
+++ b/tests/Unit/Livewire/AutocompleteTest.php
@@ -141,6 +141,29 @@ test('autocompleteResults ignores non-string types', function (): void {
         ->and($result->isEmpty())->toBeTrue();
 });
 
+test('setAutocompleteSearchParams ignores nested array types', function (): void {
+    $component = Livewire::test(Autocomplete::class);
+
+    $component->call('setAutocompleteSearchParams', [['mentions'], 'mentions'], 'username');
+
+    $component->assertSet('matchedTypes', ['mentions'])
+        ->assertSet('query', 'username');
+});
+
+test('autocompleteResults ignores nested array types', function (): void {
+    $component = Livewire::test(Autocomplete::class);
+
+    // @phpstan-ignore-next-line
+    $component->set('matchedTypes', [['mentions']]);
+    $component->set('query', 'username');
+
+    /** @var Collection $result */
+    $result = $component->instance()->autocompleteResults;
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->and($result->isEmpty())->toBeTrue();
+});
+
 test('autocompleteResults ignores unknown types but keeps valid ones', function (): void {
     $user = App\Models\User::factory()->create(['username' => 'bazz']);
 


### PR DESCRIPTION
Closes the hole in #882 that Nightwatch #32 exposed: forged matchedTypes payloads with nested arrays crashed array_intersect with Array to string conversion.

- Filters non-strings before intersecting in setAutocompleteSearchParams and autocompleteResults.
- Re-indexes filtered results so Livewire dehydrates them as a list.
- Adds 2 regression tests with nested-array payloads (fail-before verified).