### PR TITLE
refactor: improve notification handling, orphan cleanup, and view modularization

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -29,16 +29,26 @@ final readonly class NotificationController
         /** @var DatabaseNotification $notification */
         $notification = $user->notifications()->findOrFail($notification->id);
 
-        /** @var Question $question */
-        $question = Question::findOrFail($notification->data['question_id']);
+        if (isset($notification->data['question_id'])) {
+            /** @var Question|null $question */
+            $question = Question::find($notification->data['question_id']);
 
-        if ($question->answer !== null) {
-            $notification->delete();
+            if ($question === null) {
+                $notification->delete();
+
+                return to_route('notifications.index');
+            }
+
+            if ($question->answer !== null) {
+                $notification->delete();
+            }
+
+            return to_route('questions.show', [
+                'username' => $question->to->username,
+                'question' => $question,
+            ]);
         }
 
-        return to_route('questions.show', [
-            'username' => $question->to->username,
-            'question' => $question,
-        ]);
+        return to_route('notifications.index');
     }
 }

--- a/resources/views/components/notifications/item.blade.php
+++ b/resources/views/components/notifications/item.blade.php
@@ -1,0 +1,21 @@
+@props([
+    'notification',
+    'url' => route('notifications.show', ['notification' => $notification->id]),
+])
+
+<a href="{{ $url }}" wire:navigate>
+    <div class="group overflow-hidden rounded-md border border-slate-200/70 bg-white/90 p-4 shadow-sm shadow-slate-900/5 transition-colors hover:cursor-pointer hover:border-slate-300 hover:bg-slate-50 hover:shadow-md dark:border-slate-800/30 dark:bg-[#0b1324] dark:shadow-black/20 dark:hover:border-slate-700/40 dark:hover:bg-[#11192b]">
+        <div
+            class="cursor-help text-right text-xs text-slate-500 dark:text-slate-400"
+            title="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
+            datetime="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
+        >
+            {{
+                $notification->created_at->timezone(session()->get('timezone', 'UTC'))
+                    ->diffForHumans()
+            }}
+        </div>
+
+        {{ $slot }}
+    </div>
+</a>

--- a/resources/views/components/notifications/item.blade.php
+++ b/resources/views/components/notifications/item.blade.php
@@ -5,17 +5,18 @@
 
 <a href="{{ $url }}" wire:navigate>
     <div class="group overflow-hidden rounded-md border border-slate-200/70 bg-white/90 p-4 shadow-sm shadow-slate-900/5 transition-colors hover:cursor-pointer hover:border-slate-300 hover:bg-slate-50 hover:shadow-md dark:border-slate-800/30 dark:bg-[#0b1324] dark:shadow-black/20 dark:hover:border-slate-700/40 dark:hover:bg-[#11192b]">
-        <div
-            class="cursor-help text-right text-xs text-slate-500 dark:text-slate-400"
-            title="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
-            datetime="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
-        >
-            {{
-                $notification->created_at->timezone(session()->get('timezone', 'UTC'))
-                    ->diffForHumans()
-            }}
+        <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0 flex-1">{{ $slot }}</div>
+            <div
+                class="shrink-0 cursor-help text-right text-xs text-slate-500 dark:text-slate-400"
+                title="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
+                datetime="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
+            >
+                {{
+                    $notification->created_at->timezone(session()->get('timezone', 'UTC'))
+                        ->diffForHumans()
+                }}
+            </div>
         </div>
-
-        {{ $slot }}
     </div>
 </a>

--- a/resources/views/components/notifications/mention.blade.php
+++ b/resources/views/components/notifications/mention.blade.php
@@ -28,6 +28,10 @@
     </p>
 </div>
 
-@if (! $question->isSharedUpdate())
-    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $question->content !!}</p>
+@php
+    $snippet = $question->content === '__UPDATE__' ? $question->answer : $question->content;
+@endphp
+
+@if (filled($snippet))
+    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $snippet !!}</p>
 @endif

--- a/resources/views/components/notifications/mention.blade.php
+++ b/resources/views/components/notifications/mention.blade.php
@@ -1,0 +1,33 @@
+@props([
+    'notification',
+    'question',
+])
+
+@php
+    $author = ($question->isSharedUpdate() || $question->answer === null)
+        ? $question->from
+        : $question->to;
+@endphp
+
+<div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+    <figure class="{{ $author->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
+        <img
+            src="{{ $author->avatar_url }}"
+            alt="{{ $author->username }}"
+            class="{{ $author->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
+        />
+    </figure>
+    <p>
+        @if ($question->parent !== null)
+            You have been mentioned in a comment by
+            <span class="font-medium text-slate-950 dark:text-white">{{ '@' . $author->username }}</span>
+        @else
+            You have been mentioned in a {{ $question->isSharedUpdate() ? 'update by ' : 'question by ' }}<span
+             class="font-medium text-slate-950 dark:text-white">{{ '@' . $author->username }}</span>
+        @endif
+    </p>
+</div>
+
+@if (! $question->isSharedUpdate())
+    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $question->content !!}</p>
+@endif

--- a/resources/views/components/notifications/mention.blade.php
+++ b/resources/views/components/notifications/mention.blade.php
@@ -9,7 +9,7 @@
         : $question->to;
 @endphp
 
-<div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+<div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
     <figure class="{{ $author->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
         <img
             src="{{ $author->avatar_url }}"

--- a/resources/views/components/notifications/question.blade.php
+++ b/resources/views/components/notifications/question.blade.php
@@ -1,0 +1,62 @@
+@props([
+    'notification',
+    'question',
+    'user',
+])
+
+@if ($question->parent_id !== null)
+    <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+        <figure class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
+            <img
+                src="{{ $question->from->avatar_url }}"
+                alt="{{ $question->from->username }}"
+                class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
+            />
+        </figure>
+        <p>
+            <span class="font-medium text-slate-950 dark:text-white">{{ $question->from->name }}</span>
+            commented on your {{ $question->parent->parent_id !== null ? 'comment' : ($question->parent->isSharedUpdate() ? 'Update' : 'Answer') }}:
+        </p>
+    </div>
+@elseif ($question->from->is($user) && $question->answer !== null)
+    <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+        <figure class="{{ $question->to->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
+            <img
+                src="{{ $question->to->avatar_url }}"
+                alt="{{ $question->to->username }}"
+                class="{{ $question->to->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
+            />
+        </figure>
+        <p>
+            <span class="font-medium text-slate-950 dark:text-white">{{ $question->to->name }}</span>
+            answered your {{ $question->anonymously ? 'anonymous question' : 'question' }}:
+        </p>
+    </div>
+@else
+    @if ($question->anonymously)
+        <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-dashed border-slate-400">
+                <span>?</span>
+            </div>
+            <p>Someone asked you anonymously:</p>
+        </div>
+    @else
+        <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+            <figure class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
+                <img
+                    src="{{ $question->from->avatar_url }}"
+                    alt="{{ $question->from->username }}"
+                    class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
+                />
+            </figure>
+            <p>
+                <span class="font-medium text-slate-950 dark:text-white">{{ $question->from->name }}</span>
+                asked you:
+            </p>
+        </div>
+    @endif
+@endif
+
+@if (! $question->isSharedUpdate())
+    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $question->content !!}</p>
+@endif

--- a/resources/views/components/notifications/question.blade.php
+++ b/resources/views/components/notifications/question.blade.php
@@ -5,7 +5,7 @@
 ])
 
 @if ($question->parent_id !== null)
-    <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+    <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
         <figure class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
             <img
                 src="{{ $question->from->avatar_url }}"
@@ -19,7 +19,7 @@
         </p>
     </div>
 @elseif ($question->from->is($user) && $question->answer !== null)
-    <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+    <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
         <figure class="{{ $question->to->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
             <img
                 src="{{ $question->to->avatar_url }}"
@@ -34,14 +34,14 @@
     </div>
 @else
     @if ($question->anonymously)
-        <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+        <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
             <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-dashed border-slate-400">
                 <span>?</span>
             </div>
             <p>Someone asked you anonymously:</p>
         </div>
     @else
-        <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+        <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
             <figure class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
                 <img
                     src="{{ $question->from->avatar_url }}"

--- a/resources/views/components/notifications/question.blade.php
+++ b/resources/views/components/notifications/question.blade.php
@@ -57,6 +57,10 @@
     @endif
 @endif
 
-@if (! $question->isSharedUpdate())
-    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $question->content !!}</p>
+@php
+    $snippet = $question->content === '__UPDATE__' ? $question->answer : $question->content;
+@endphp
+
+@if (filled($snippet))
+    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $snippet !!}</p>
 @endif

--- a/resources/views/livewire/notifications/index.blade.php
+++ b/resources/views/livewire/notifications/index.blade.php
@@ -11,96 +11,29 @@
     @endif
 
     @foreach ($notifications as $notification)
-        @php
-            /** @var Question|null $question */
-            $question = $questions->get($notification->data['question_id'] ?? null);
-            $isMention = $notification->type === 'App\Notifications\UserMentioned';
-        @endphp
+        @if ($notification->type === 'App\Notifications\UserMentioned')
+            @php
+                /** @var Question|null $question */
+                $question = $questions->get($notification->data['question_id'] ?? null);
+            @endphp
 
-        @continue($question === null)
+            @if ($question !== null)
+                <x-notifications.item :notification="$notification">
+                    <x-notifications.mention :notification="$notification" :question="$question" />
+                </x-notifications.item>
+            @endif
+        @elseif (in_array($notification->type, ['App\Notifications\QuestionCreated', 'App\Notifications\QuestionAnswered'], true))
+            @php
+                /** @var Question|null $question */
+                $question = $questions->get($notification->data['question_id'] ?? null);
+            @endphp
 
-        <a href="{{ route('notifications.show', ['notification' => $notification->id]) }}" wire:navigate>
-            <div class="group overflow-hidden rounded-md border border-slate-200/70 bg-white/90 p-4 shadow-sm shadow-slate-900/5 transition-colors hover:cursor-pointer hover:border-slate-300 hover:bg-slate-50 hover:shadow-md dark:border-slate-800/30 dark:bg-[#0b1324] dark:shadow-black/20 dark:hover:border-slate-700/40 dark:hover:bg-[#11192b]">
-                <div
-                    class="cursor-help text-right text-xs text-slate-500 dark:text-slate-400"
-                    title="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
-                    datetime="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
-                >
-                    {{
-                        $notification->created_at->timezone(session()->get('timezone', 'UTC'))
-                            ->diffForHumans()
-                    }}
-                </div>
-                @if (! $isMention)
-                    @if ($question->parent_id !== null)
-                        <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-                            <figure class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
-                                <img
-                                    src="{{ $question->from->avatar_url }}"
-                                    alt="{{ $question->from->username }}"
-                                    class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
-                                />
-                            </figure>
-                            <p>
-                                <span class="font-medium text-slate-950 dark:text-white">{{ $question->from->name }}</span>
-                                commented on your {{ $question->parent->parent_id !== null ? 'comment' : ($question->parent->isSharedUpdate() ? 'Update' : 'Answer') }}:
-                            </p>
-                        </div>
-                    @elseif ($question->from->is(auth()->user()) && $question->answer !== null)
-                        <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-                            <figure class="{{ $question->to->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
-                                <img
-                                    src="{{ $question->to->avatar_url }}"
-                                    alt="{{ $question->to->username }}"
-                                    class="{{ $question->to->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
-                                />
-                            </figure>
-                            <p>
-                                <span class="font-medium text-slate-950 dark:text-white">{{ $question->to->name }}</span>
-                                answered your {{ $question->anonymously ? 'anonymous question' : 'question' }}:
-                            </p>
-                        </div>
-                    @else
-                        @if ($question->anonymously)
-                            <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-                                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-dashed border-slate-400">
-                                    <span>?</span>
-                                </div>
-                                <p>Someone asked you anonymously:</p>
-                            </div>
-                        @else
-                            <div class="mt-3 flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-                                <figure class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
-                                    <img
-                                        src="{{ $question->from->avatar_url }}"
-                                        alt="{{ $question->from->username }}"
-                                        class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
-                                    />
-                                </figure>
-                                <p>
-                                    <span class="font-medium text-slate-950 dark:text-white">{{ $question->from->name }}</span>
-                                    asked you:
-                                </p>
-                            </div>
-                        @endif
-                    @endif
-                @elseif ($question->parent !== null)
-                    <p class="mt-3 text-sm text-slate-600 dark:text-slate-400">
-                        You have been mentioned in a comment by
-                        <span class="font-medium text-slate-950 dark:text-white">{{ '@' . $question->to->username }}</span>
-                    </p>
-                @else
-                    <p class="mt-3 text-sm text-slate-600 dark:text-slate-400">
-                        You have been mentioned in a {{ $question->isSharedUpdate() ? 'update by ' : 'question by ' }}<span
-                            class="font-medium text-slate-950 dark:text-white"
-                            >{{ '@' . $question->to->username }}</span>
-                    </p>
-                @endif
-                @if (! $question->isSharedUpdate())
-                    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $question->content !!}</p>
-                @endif
-            </div>
-        </a>
+            @if ($question !== null)
+                <x-notifications.item :notification="$notification">
+                    <x-notifications.question :notification="$notification" :question="$question" :user="$user" />
+                </x-notifications.item>
+            @endif
+        @endif
     @endforeach
 
     @if ($notifications->hasPages())

--- a/resources/views/livewire/notifications/index.blade.php
+++ b/resources/views/livewire/notifications/index.blade.php
@@ -1,53 +1,63 @@
-<div class="mb-20 flex flex-col gap-3">
-    @if ($notifications->count() > 0)
-        <div class="mb-2 flex items-center justify-end">
+<div>
+    <div class="sticky -top-1 z-30 flex items-center justify-between border-b border-slate-200/70 bg-white px-6 py-4 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
+        <h2 class="text-[2rem] font-semibold tracking-tight text-slate-950 dark:text-white">Notifications</h2>
+
+        @if ($notifications->count() > 0)
             <button
                 class="inline-flex items-center rounded-full border border-slate-200/70 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-950 dark:border-slate-800/30 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
                 wire:click="ignoreAll('{{ now() }}')"
             >
                 Ignore all
             </button>
-        </div>
-    @endif
-
-    @foreach ($notifications as $notification)
-        @if ($notification->type === 'App\Notifications\UserMentioned')
-            @php
-                /** @var Question|null $question */
-                $question = $questions->get($notification->data['question_id'] ?? null);
-            @endphp
-
-            @if ($question !== null)
-                <x-notifications.item :notification="$notification">
-                    <x-notifications.mention :notification="$notification" :question="$question" />
-                </x-notifications.item>
-            @endif
-        @elseif (in_array($notification->type, ['App\Notifications\QuestionCreated', 'App\Notifications\QuestionAnswered'], true))
-            @php
-                /** @var Question|null $question */
-                $question = $questions->get($notification->data['question_id'] ?? null);
-            @endphp
-
-            @if ($question !== null)
-                <x-notifications.item :notification="$notification">
-                    <x-notifications.question :notification="$notification" :question="$question" :user="$user" />
-                </x-notifications.item>
-            @endif
         @endif
-    @endforeach
+    </div>
 
-    @if ($notifications->hasPages())
-        <div class="mt-4">{{ $notifications->links() }}</div>
-    @endif
+    <div class="min-h-screen p-4 sm:p-6">
+        <div class="mb-20 flex flex-col gap-3">
+            @foreach ($notifications as $notification)
+                @if ($notification->type === 'App\Notifications\UserMentioned')
+                    @php
+                        /** @var Question|null $question */
+                        $question = $questions->get($notification->data['question_id'] ?? null);
+                    @endphp
 
-    @if ($notifications->count() === 0)
-        <div class="flex min-h-96 items-center justify-center rounded-md border border-dashed border-slate-300/80 bg-slate-50/70 px-6 text-center dark:border-slate-700/80 dark:bg-slate-900/50">
-            <div>
-                <p class="text-lg font-medium text-slate-950 dark:text-white">No pending notifications.</p>
-                <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
-                    New replies, mentions, and questions will show up here.
-                </p>
-            </div>
+                    @if ($question !== null)
+                        <x-notifications.item :notification="$notification">
+                            <x-notifications.mention :notification="$notification" :question="$question" />
+                        </x-notifications.item>
+                    @endif
+                @elseif (in_array($notification->type, ['App\Notifications\QuestionCreated', 'App\Notifications\QuestionAnswered'], true))
+                    @php
+                        /** @var Question|null $question */
+                        $question = $questions->get($notification->data['question_id'] ?? null);
+                    @endphp
+
+                    @if ($question !== null)
+                        <x-notifications.item :notification="$notification">
+                            <x-notifications.question
+                                :notification="$notification"
+                                :question="$question"
+                                :user="$user"
+                            />
+                        </x-notifications.item>
+                    @endif
+                @endif
+            @endforeach
+
+            @if ($notifications->hasPages())
+                <div class="mt-4">{{ $notifications->links() }}</div>
+            @endif
+
+            @if ($notifications->count() === 0)
+                <div class="flex min-h-96 items-center justify-center rounded-md border border-dashed border-slate-300/80 bg-slate-50/70 px-6 text-center dark:border-slate-700/80 dark:bg-slate-900/50">
+                    <div>
+                        <p class="text-lg font-medium text-slate-950 dark:text-white">No pending notifications.</p>
+                        <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                            New replies, mentions, and questions will show up here.
+                        </p>
+                    </div>
+                </div>
+            @endif
         </div>
-    @endif
+    </div>
 </div>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -1,11 +1,5 @@
 <x-app-layout>
     <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
-        <div class="sticky -top-1 z-30 flex items-center justify-between border-b border-slate-200/70 bg-white px-6 py-4 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
-            <h2 class="text-[2rem] font-semibold tracking-tight text-slate-950 dark:text-white">Notifications</h2>
-        </div>
-
-        <div class="min-h-screen p-4 sm:p-6">
-            <livewire:notifications-index />
-        </div>
+        <livewire:notifications-index />
     </section>
 </x-app-layout>

--- a/tests/Http/Notifications/ShowTest.php
+++ b/tests/Http/Notifications/ShowTest.php
@@ -71,3 +71,23 @@ test('notifications about questions are not deleted', function (): void {
     $response->assertRedirectToRoute('questions.show', ['question' => $question, 'username' => $question->to->username]);
     expect($notification->fresh())->not->toBeNull();
 });
+
+test('orphan notification is deleted and redirects to notifications index', function (): void {
+    $user = App\Models\User::factory()->create();
+
+    $notification = Illuminate\Notifications\DatabaseNotification::query()->create([
+        'id' => Illuminate\Support\Str::uuid()->toString(),
+        'type' => App\Notifications\QuestionCreated::class,
+        'notifiable_type' => $user::class,
+        'notifiable_id' => $user->getKey(),
+        'data' => ['question_id' => Illuminate\Support\Str::uuid()->toString()],
+    ]);
+
+    $response = $this->actingAs($user)
+        ->get(route('notifications.show', [
+            'notification' => $notification,
+        ]));
+
+    $response->assertRedirectToRoute('notifications.index');
+    expect($notification->fresh())->toBeNull();
+});

--- a/tests/Unit/Livewire/Notifications/IndexTest.php
+++ b/tests/Unit/Livewire/Notifications/IndexTest.php
@@ -8,6 +8,7 @@ use App\Models\Question;
 use App\Models\User;
 use App\Notifications\QuestionAnswered;
 use App\Notifications\QuestionCreated;
+use App\Notifications\UserMentioned;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -182,4 +183,26 @@ test('ignores all notifications viewed by user', function (): void {
         ->and($user->questionsReceived()->where('is_ignored', true)->count())->toBe(2);
 
     $component->assertSee('Ignore all');
+});
+
+test('displays mention notifications with author avatar and username', function (): void {
+    $userA = User::factory()->create(['username' => 'alice']);
+    $userB = User::factory()->create(['username' => 'bob']);
+
+    $question = Question::factory()->create([
+        'to_id' => $userB->id,
+        'from_id' => $userA->id,
+        'content' => 'Hello @bob',
+        'answer' => null,
+    ]);
+
+    $userB->notify(new UserMentioned($question));
+
+    /** @var Testable $component */
+    $component = Livewire::actingAs($userB->fresh())->test(Index::class);
+
+    $component
+        ->assertSee('@alice')
+        ->assertSee('Hello')
+        ->assertSee('@bob');
 });


### PR DESCRIPTION
### What:

- [x] Refactoring
- [x] Bug Fix

### Description:

This PR improves core notification stability and modularity as the foundation for the notification improvements stack:

1. **Polymorphic Notification Handling & Orphan Safety**:
   - `NotificationController::show()` now gracefully handles cases where the underlying referenced model was deleted, safely deleting the orphan notification and falling back to `notifications.index` instead of throwing a 404/500 error.
2. **Real Update Fallback**:
   - For comments and updates where `content === '__UPDATE__'`, notifications now display the real update text from `$question->answer` rather than the internal sentinel value.
3. **Component Modularization**:
   - Extracted notification card templates into dedicated components (`components/notifications/item`, `question`, `mention`) for clean separation of concerns.
4. **Header Alignment**:
   - Aligned the "Ignore all" button in the sticky top header alongside the Notifications title.
5. **Tests**:
   - Added feature tests in `ShowTest` and `IndexTest` verifying orphan cleanup, fallback redirects, and mention rendering.

Part of Stack #896 (Layer 1 of 3).
