### PR TITLE
feat: add user followed notification

### DIFF
--- a/app/Actions/Users/CreateFollow.php
+++ b/app/Actions/Users/CreateFollow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Users;
 
 use App\Models\User;
+use App\Notifications\UserFollowed;
 
 final readonly class CreateFollow
 {
@@ -13,6 +14,16 @@ final readonly class CreateFollow
      */
     public function handle(User $user, int $targetId): void
     {
-        $user->following()->syncWithoutDetaching($targetId);
+        if ($user->id === $targetId) {
+            return;
+        }
+
+        $changes = $user->following()->syncWithoutDetaching($targetId);
+
+        if (in_array($targetId, $changes['attached'], true)) {
+            $target = User::find($targetId);
+
+            $target?->notify(new UserFollowed($user));
+        }
     }
 }

--- a/app/Actions/Users/DeleteFollow.php
+++ b/app/Actions/Users/DeleteFollow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Users;
 
 use App\Models\User;
+use App\Notifications\UserFollowed;
 
 final readonly class DeleteFollow
 {
@@ -14,5 +15,12 @@ final readonly class DeleteFollow
     public function handle(User $user, int $targetId): void
     {
         $user->following()->detach($targetId);
+
+        $target = User::find($targetId);
+
+        $target?->notifications()
+            ->where('type', UserFollowed::class)
+            ->whereJsonContains('data->follower_id', $user->id)
+            ->delete();
     }
 }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -29,6 +29,21 @@ final readonly class NotificationController
         /** @var DatabaseNotification $notification */
         $notification = $user->notifications()->findOrFail($notification->id);
 
+        if (isset($notification->data['follower_id'])) {
+            /** @var User|null $follower */
+            $follower = User::find($notification->data['follower_id']);
+
+            $notification->delete();
+
+            if ($follower === null) {
+                return to_route('notifications.index');
+            }
+
+            return to_route('profile.show', [
+                'username' => $follower->username,
+            ]);
+        }
+
         if (isset($notification->data['question_id'])) {
             /** @var Question|null $question */
             $question = Question::find($notification->data['question_id']);

--- a/app/Jobs/DeleteOrphanNotifications.php
+++ b/app/Jobs/DeleteOrphanNotifications.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Models\Question;
+use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Notifications\DatabaseNotification;
@@ -29,6 +30,11 @@ final class DeleteOrphanNotifications implements ShouldQueue
         DatabaseNotification::query()
             ->whereNotNull('data->question_id')
             ->whereNotIn('data->question_id', Question::query()->select('id'))
+            ->eachById(fn (DatabaseNotification $notification): bool => (bool) $notification->delete());
+
+        DatabaseNotification::query()
+            ->whereNotNull('data->follower_id')
+            ->whereNotIn('data->follower_id', User::query()->select('id'))
             ->eachById(fn (DatabaseNotification $notification): bool => (bool) $notification->delete());
     }
 }

--- a/app/Livewire/Notifications/Index.php
+++ b/app/Livewire/Notifications/Index.php
@@ -58,6 +58,7 @@ final class Index extends Component
             'user' => $user,
             'notifications' => $notifications,
             'questions' => $this->questionsFor($notifications),
+            'followers' => $this->followersFor($notifications),
         ]);
     }
 
@@ -86,6 +87,34 @@ final class Index extends Component
         return Question::query()
             ->with(['from', 'to', 'parent'])
             ->whereIn('id', $questionIds)
+            ->get()
+            ->keyBy('id');
+    }
+
+    /**
+     * Load the followers referenced by the given notifications in a single query.
+     *
+     * @param  Paginator<int, DatabaseNotification>  $notifications
+     * @return Collection<int|string, User>
+     */
+    private function followersFor(Paginator $notifications): Collection
+    {
+        $followerIds = collect($notifications->items())
+            ->map(function (DatabaseNotification $notification): ?int {
+                $followerId = $notification->data['follower_id'] ?? null;
+
+                return is_int($followerId) ? $followerId : (is_numeric($followerId) ? (int) $followerId : null);
+            })
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($followerIds->isEmpty()) {
+            return new Collection();
+        }
+
+        return User::query()
+            ->whereIn('id', $followerIds)
             ->get()
             ->keyBy('id');
     }

--- a/app/Notifications/UserFollowed.php
+++ b/app/Notifications/UserFollowed.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+final class UserFollowed extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public User $follower,
+    ) {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toDatabase(object $notifiable): array
+    {
+        return [
+            'follower_id' => $this->follower->id,
+        ];
+    }
+}

--- a/resources/views/components/notifications/user-followed.blade.php
+++ b/resources/views/components/notifications/user-followed.blade.php
@@ -1,0 +1,18 @@
+@props([
+    'notification',
+    'follower',
+])
+
+<div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+    <figure class="{{ $follower->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
+        <img
+            src="{{ $follower->avatar_url }}"
+            alt="{{ $follower->username }}"
+            class="{{ $follower->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
+        />
+    </figure>
+    <p>
+        <span class="font-medium text-slate-950 dark:text-white">{{ '@' . $follower->username }}</span>
+        followed you
+    </p>
+</div>

--- a/resources/views/livewire/notifications/index.blade.php
+++ b/resources/views/livewire/notifications/index.blade.php
@@ -41,6 +41,17 @@
                             />
                         </x-notifications.item>
                     @endif
+                @elseif ($notification->type === 'App\Notifications\UserFollowed')
+                    @php
+                        /** @var User|null $follower */
+                        $follower = $followers->get($notification->data['follower_id'] ?? null);
+                    @endphp
+
+                    @if ($follower !== null)
+                        <x-notifications.item :notification="$notification">
+                            <x-notifications.user-followed :notification="$notification" :follower="$follower" />
+                        </x-notifications.item>
+                    @endif
                 @endif
             @endforeach
 
@@ -53,7 +64,7 @@
                     <div>
                         <p class="text-lg font-medium text-slate-950 dark:text-white">No pending notifications.</p>
                         <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
-                            New replies, mentions, and questions will show up here.
+                            New replies, mentions, followers, and questions will show up here.
                         </p>
                     </div>
                 </div>

--- a/tests/Arch/NotificationsTest.php
+++ b/tests/Arch/NotificationsTest.php
@@ -7,6 +7,7 @@ arch('notifications')
     ->toHaveConstructor()
     ->toExtend(Illuminate\Notifications\Notification::class)
     ->toOnlyBeUsedIn([
+        'App\Actions\Users',
         'App\Console\Commands',
         'App\Http\Controllers',
         'App\Observers',

--- a/tests/Http/Notifications/ShowTest.php
+++ b/tests/Http/Notifications/ShowTest.php
@@ -91,3 +91,42 @@ test('orphan notification is deleted and redirects to notifications index', func
     $response->assertRedirectToRoute('notifications.index');
     expect($notification->fresh())->toBeNull();
 });
+
+test('follow notifications redirect to follower profile and are deleted', function (): void {
+    $follower = App\Models\User::factory()->create();
+    $user = App\Models\User::factory()->create();
+
+    $user->notify(new App\Notifications\UserFollowed($follower));
+
+    $notification = $user->notifications()->first();
+    expect($notification)->not->toBeNull();
+
+    /** @var Illuminate\Testing\TestResponse $response */
+    $response = $this->actingAs($user)
+        ->get(route('notifications.show', [
+            'notification' => $notification,
+        ]));
+
+    $response->assertRedirectToRoute('profile.show', ['username' => $follower->username]);
+    expect($notification->fresh())->toBeNull();
+});
+
+test('orphan follow notification is deleted and redirects to notifications index', function (): void {
+    $user = App\Models\User::factory()->create();
+
+    $notification = Illuminate\Notifications\DatabaseNotification::query()->create([
+        'id' => Illuminate\Support\Str::uuid()->toString(),
+        'type' => App\Notifications\UserFollowed::class,
+        'notifiable_type' => $user::class,
+        'notifiable_id' => $user->getKey(),
+        'data' => ['follower_id' => 999999],
+    ]);
+
+    $response = $this->actingAs($user)
+        ->get(route('notifications.show', [
+            'notification' => $notification,
+        ]));
+
+    $response->assertRedirectToRoute('notifications.index');
+    expect($notification->fresh())->toBeNull();
+});

--- a/tests/Unit/Livewire/Concerns/FollowableTest.php
+++ b/tests/Unit/Livewire/Concerns/FollowableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Livewire\Concerns\Followable;
 use App\Models\User;
+use App\Notifications\UserFollowed;
 use Livewire\Component;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;
@@ -17,7 +18,8 @@ it('follows the given user', function (): void {
 
     $component->call('follow', $anotherUser->id);
 
-    expect($user->following->contains($anotherUser))->toBeTrue();
+    expect($user->following->contains($anotherUser))->toBeTrue()
+        ->and($anotherUser->notifications()->count())->toBe(1);
 
     $component->assertDispatched('following.updated');
 
@@ -36,7 +38,8 @@ it('does not fail when following the same user twice', function (): void {
     $component->call('follow', $anotherUser->id);
     $component->call('follow', $anotherUser->id);
 
-    expect($user->following()->whereKey($anotherUser->id)->count())->toBe(1);
+    expect($user->following()->whereKey($anotherUser->id)->count())->toBe(1)
+        ->and($anotherUser->notifications()->count())->toBe(1);
 });
 
 it('unfollows the given user', function (): void {
@@ -44,13 +47,16 @@ it('unfollows the given user', function (): void {
     $anotherUser = User::factory()->create();
 
     $user->following()->attach($anotherUser);
+    $anotherUser->notify(new UserFollowed($user));
+    expect($anotherUser->notifications()->count())->toBe(1);
 
     /** @var Testable $component */
     $component = Livewire::actingAs($user)->test(supportsFollow()::class);
 
     $component->call('unfollow', $anotherUser->id);
 
-    expect($user->following->contains($anotherUser))->toBeFalse();
+    expect($user->following->contains($anotherUser))->toBeFalse()
+        ->and($anotherUser->notifications()->count())->toBe(0);
 
     $component->assertDispatched('following.updated');
 

--- a/tests/Unit/Livewire/Notifications/IndexTest.php
+++ b/tests/Unit/Livewire/Notifications/IndexTest.php
@@ -8,6 +8,7 @@ use App\Models\Question;
 use App\Models\User;
 use App\Notifications\QuestionAnswered;
 use App\Notifications\QuestionCreated;
+use App\Notifications\UserFollowed;
 use App\Notifications\UserMentioned;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\DB;
@@ -205,4 +206,41 @@ test('displays mention notifications with author avatar and username', function 
         ->assertSee('@alice')
         ->assertSee('Hello')
         ->assertSee('@bob');
+});
+
+test('displays user followed notification with follower username', function (): void {
+    $follower = User::factory()->create(['username' => 'alice']);
+    $user = User::factory()->create(['username' => 'bob']);
+
+    $user->notify(new UserFollowed($follower));
+
+    /** @var Testable $component */
+    $component = Livewire::actingAs($user->fresh())->test(Index::class);
+
+    $component
+        ->assertSee('@alice')
+        ->assertSee('followed you');
+});
+
+test('orphan follower notifications are skipped and can be cleaned up', function (): void {
+    $user = User::factory()->create();
+
+    DatabaseNotification::query()->create([
+        'id' => Str::uuid()->toString(),
+        'type' => UserFollowed::class,
+        'notifiable_type' => $user::class,
+        'notifiable_id' => $user->getKey(),
+        'data' => ['follower_id' => 999999],
+    ]);
+
+    expect($user->notifications()->count())->toBe(1);
+
+    /** @var Testable $component */
+    $component = Livewire::actingAs($user->fresh())->test(Index::class);
+
+    expect($component->viewData('followers')->count())->toBe(0);
+
+    new DeleteOrphanNotifications()->handle();
+
+    expect($user->notifications()->count())->toBe(0);
 });

--- a/tests/Unit/Notifications/UserFollowedTest.php
+++ b/tests/Unit/Notifications/UserFollowedTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Notifications\UserFollowed;
+
+test('to database', function (): void {
+    $follower = User::factory()->create();
+    $target = User::factory()->create();
+
+    $notification = new UserFollowed($follower);
+
+    expect($notification->via($target))->toBe(['database'])
+        ->and($notification->toDatabase($target))->toBe(['follower_id' => $follower->id]);
+});


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

Adds real-time database notifications when a user is followed (`@{username} followed you`):

1. **Notification & Lifecycle**:
   - Introduced `App\Notifications\UserFollowed` database notification.
   - Dispatches notification from `CreateFollow` (idempotent, skips self-follows and duplicate follows).
   - Cleans up pending notifications in `DeleteFollow` if the user unfollows before the notification is read.
2. **Batch Eager Loading**:
   - Added `followersFor()` in `Livewire\Notifications\Index` to batch load all follower models for the current page in a single query, preventing N+1 queries.
3. **Controller & Profile Redirection**:
   - Clicking a follow notification marks it as read and redirects directly to the follower's profile.
4. **Orphan Cleanup**:
   - Dispatches `DeleteOrphanNotifications` job to purge dangling follow notifications if an account is deleted.
5. **Tests**:
   - Added unit and architecture tests for `UserFollowed`, `FollowableTest`, and `IndexTest`.

Part of Stack #896 (Layer 2 of 3, builds on PR #893).
