### PR TITLE
feat(ui): redesign notifications to match feed post layout

### DIFF
--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,4 +1,4 @@
-<footer class="border-t border-slate-200/70 bg-white/75 backdrop-blur dark:border-white/5 dark:bg-black/20">
+<footer class="border-t border-slate-200/70 bg-white/75 pb-24 backdrop-blur lg:pb-0 dark:border-white/5 dark:bg-black/20">
     <div class="mx-auto flex w-full max-w-328 flex-col gap-6 px-4 py-8 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-8">
         <div>
             <p class="font-mona text-lg font-semibold text-slate-950 dark:text-white">{{ config('app.name') }}</p>

--- a/resources/views/components/notifications/item.blade.php
+++ b/resources/views/components/notifications/item.blade.php
@@ -3,20 +3,12 @@
     'url' => route('notifications.show', ['notification' => $notification->id]),
 ])
 
-<a href="{{ $url }}" wire:navigate>
-    <div class="group overflow-hidden rounded-md border border-slate-200/70 bg-white/90 p-4 shadow-sm shadow-slate-900/5 transition-colors hover:cursor-pointer hover:border-slate-300 hover:bg-slate-50 hover:shadow-md dark:border-slate-800/30 dark:bg-[#0b1324] dark:shadow-black/20 dark:hover:border-slate-700/40 dark:hover:bg-[#11192b]">
-        <div class="flex items-start justify-between gap-4">
-            <div class="min-w-0 flex-1">{{ $slot }}</div>
-            <div
-                class="shrink-0 cursor-help text-right text-xs text-slate-500 dark:text-slate-400"
-                title="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
-                datetime="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
-            >
-                {{
-                    $notification->created_at->timezone(session()->get('timezone', 'UTC'))
-                        ->diffForHumans()
-                }}
-            </div>
-        </div>
-    </div>
-</a>
+<div
+    data-parent="true"
+    x-data="clickHandler"
+    x-on:click="handleNavigation($event)"
+    class="block cursor-pointer border-b border-slate-200/70 px-4 py-3.5 transition-colors hover:bg-slate-50/80 sm:px-6 sm:py-4 dark:border-slate-800/40 dark:hover:bg-[#0a1325]"
+>
+    <a href="{{ $url }}" wire:navigate x-ref="parentLink" class="hidden"></a>
+    {{ $slot }}
+</div>

--- a/resources/views/components/notifications/mention.blade.php
+++ b/resources/views/components/notifications/mention.blade.php
@@ -4,34 +4,63 @@
 ])
 
 @php
-    $author = ($question->isSharedUpdate() || $question->answer === null)
+    $author = ($question->parent_id !== null || $question->content === '__UPDATE__' || $question->answer === null)
         ? $question->from
         : $question->to;
-@endphp
-
-<div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-    <figure class="{{ $author->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
-        <img
-            src="{{ $author->avatar_url }}"
-            alt="{{ $author->username }}"
-            class="{{ $author->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
-        />
-    </figure>
-    <p>
-        @if ($question->parent !== null)
-            You have been mentioned in a comment by
-            <span class="font-medium text-slate-950 dark:text-white">{{ '@' . $author->username }}</span>
-        @else
-            You have been mentioned in a {{ $question->isSharedUpdate() ? 'update by ' : 'question by ' }}<span
-             class="font-medium text-slate-950 dark:text-white">{{ '@' . $author->username }}</span>
-        @endif
-    </p>
-</div>
-
-@php
     $snippet = $question->content === '__UPDATE__' ? $question->answer : $question->content;
 @endphp
 
-@if (filled($snippet))
-    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $snippet !!}</p>
-@endif
+<div class="flex items-start gap-3 sm:gap-4">
+    <figure class="{{ $author->is_company_verified ? 'rounded-2xl' : 'rounded-full' }} h-10 w-10 sm:h-12 sm:w-12 shrink-0 overflow-hidden border border-slate-200/70 bg-slate-100 transition-opacity group-hover:opacity-90 dark:border-slate-800/30 dark:bg-[#10182b]">
+        <img
+            src="{{ $author->avatar_url }}"
+            alt="{{ $author->username }}"
+            class="{{ $author->is_company_verified ? 'rounded-2xl' : 'rounded-full' }} h-10 w-10 sm:h-12 sm:w-12"
+        />
+    </figure>
+
+    <div class="min-w-0 flex-1 py-0.5">
+        <div class="flex items-center justify-between gap-x-2">
+            <div class="flex min-w-0 flex-1 items-center gap-x-1.5 text-sm">
+                <p class="truncate font-medium text-slate-950 dark:text-white">{{ $author->name }}</p>
+
+                @if ($author->is_verified && $author->is_company_verified)
+                    <x-icons.verified-company :color="$author->right_color" class="h-3.5 w-3.5 shrink-0" />
+                @elseif ($author->is_verified)
+                    <x-icons.verified :color="$author->right_color" class="h-3.5 w-3.5 shrink-0" />
+                @endif
+
+                <p class="truncate text-slate-500 transition-colors group-hover:text-slate-600 dark:text-slate-400 dark:group-hover:text-slate-300">
+                    {{ '@'.$author->username }}
+                </p>
+            </div>
+
+            <div class="flex shrink-0 items-center gap-2 text-[0.82rem] text-slate-500 dark:text-slate-400">
+                <time
+                    class="inline-flex cursor-help items-center whitespace-nowrap"
+                    title="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
+                    datetime="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
+                >
+                    {{
+                        $notification->created_at->timezone(session()->get('timezone', 'UTC'))
+                            ->diffForHumans(short: true)
+                    }}
+                </time>
+            </div>
+        </div>
+
+        <p class="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+            @if ($question->parent !== null)
+                mentioned you in a comment:
+            @else
+                mentioned you in {{ $question->isSharedUpdate() ? 'an update:' : 'a question:' }}
+            @endif
+        </p>
+
+        @if (filled($snippet))
+            <div class="mt-1.5 line-clamp-3 text-sm leading-6 break-words text-slate-700 dark:text-slate-200">
+                {!! $snippet !!}
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/components/notifications/question.blade.php
+++ b/resources/views/components/notifications/question.blade.php
@@ -4,63 +4,81 @@
     'user',
 ])
 
-@if ($question->parent_id !== null)
-    <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-        <figure class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
-            <img
-                src="{{ $question->from->avatar_url }}"
-                alt="{{ $question->from->username }}"
-                class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
-            />
-        </figure>
-        <p>
-            <span class="font-medium text-slate-950 dark:text-white">{{ $question->from->name }}</span>
-            commented on your {{ $question->parent->parent_id !== null ? 'comment' : ($question->parent->isSharedUpdate() ? 'Update' : 'Answer') }}:
-        </p>
-    </div>
-@elseif ($question->from->is($user) && $question->answer !== null)
-    <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-        <figure class="{{ $question->to->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
-            <img
-                src="{{ $question->to->avatar_url }}"
-                alt="{{ $question->to->username }}"
-                class="{{ $question->to->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
-            />
-        </figure>
-        <p>
-            <span class="font-medium text-slate-950 dark:text-white">{{ $question->to->name }}</span>
-            answered your {{ $question->anonymously ? 'anonymous question' : 'question' }}:
-        </p>
-    </div>
-@else
-    @if ($question->anonymously)
-        <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-dashed border-slate-400">
-                <span>?</span>
-            </div>
-            <p>Someone asked you anonymously:</p>
-        </div>
-    @else
-        <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-            <figure class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
-                <img
-                    src="{{ $question->from->avatar_url }}"
-                    alt="{{ $question->from->username }}"
-                    class="{{ $question->from->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
-                />
-            </figure>
-            <p>
-                <span class="font-medium text-slate-950 dark:text-white">{{ $question->from->name }}</span>
-                asked you:
-            </p>
-        </div>
-    @endif
-@endif
-
 @php
+    $isComment = $question->parent_id !== null;
+    $isAnswer = ! $isComment && $question->from->is($user) && $question->answer !== null;
+    $isAnonymous = ! $isComment && ! $isAnswer && $question->anonymously;
+
+    if ($isComment) {
+        $actor = $question->from;
+        $action = 'commented on your '.($question->parent->parent_id !== null ? 'comment:' : ($question->parent->isSharedUpdate() ? 'Update:' : 'Answer:'));
+    } elseif ($isAnswer) {
+        $actor = $question->to;
+        $action = 'answered your '.($question->anonymously ? 'anonymous question:' : 'question:');
+    } elseif ($isAnonymous) {
+        $actor = null;
+        $action = 'asked you anonymously:';
+    } else {
+        $actor = $question->from;
+        $action = 'asked you:';
+    }
+
     $snippet = $question->content === '__UPDATE__' ? $question->answer : $question->content;
 @endphp
 
-@if (filled($snippet))
-    <p class="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{!! $snippet !!}</p>
-@endif
+<div class="flex items-start gap-3 sm:gap-4">
+    @if ($actor !== null)
+        <figure class="{{ $actor->is_company_verified ? 'rounded-2xl' : 'rounded-full' }} h-10 w-10 sm:h-12 sm:w-12 shrink-0 overflow-hidden border border-slate-200/70 bg-slate-100 transition-opacity group-hover:opacity-90 dark:border-slate-800/30 dark:bg-[#10182b]">
+            <img
+                src="{{ $actor->avatar_url }}"
+                alt="{{ $actor->username }}"
+                class="{{ $actor->is_company_verified ? 'rounded-2xl' : 'rounded-full' }} h-10 w-10 sm:h-12 sm:w-12"
+            />
+        </figure>
+    @else
+        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-dashed border-slate-300 bg-slate-100 sm:h-12 sm:w-12 dark:border-slate-700 dark:bg-[#10182b]">
+            <span class="text-sm font-medium text-slate-500 dark:text-slate-400">?</span>
+        </div>
+    @endif
+
+    <div class="min-w-0 flex-1 py-0.5">
+        <div class="flex items-center justify-between gap-x-2">
+            <div class="flex min-w-0 flex-1 items-center gap-x-1.5 text-sm">
+                <p class="truncate font-medium text-slate-950 dark:text-white">{{ $actor?->name ?? 'Anonymous' }}</p>
+
+                @if ($actor?->is_verified && $actor?->is_company_verified)
+                    <x-icons.verified-company :color="$actor->right_color" class="h-3.5 w-3.5 shrink-0" />
+                @elseif ($actor?->is_verified)
+                    <x-icons.verified :color="$actor->right_color" class="h-3.5 w-3.5 shrink-0" />
+                @endif
+
+                @if ($actor?->username)
+                    <p class="truncate text-slate-500 transition-colors group-hover:text-slate-600 dark:text-slate-400 dark:group-hover:text-slate-300">
+                        {{ '@'.$actor->username }}
+                    </p>
+                @endif
+            </div>
+
+            <div class="flex shrink-0 items-center gap-2 text-[0.82rem] text-slate-500 dark:text-slate-400">
+                <time
+                    class="inline-flex cursor-help items-center whitespace-nowrap"
+                    title="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
+                    datetime="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
+                >
+                    {{
+                        $notification->created_at->timezone(session()->get('timezone', 'UTC'))
+                            ->diffForHumans(short: true)
+                    }}
+                </time>
+            </div>
+        </div>
+
+        <p class="mt-0.5 text-xs text-slate-500 dark:text-slate-400">{{ $action }}</p>
+
+        @if (filled($snippet))
+            <div class="mt-1.5 line-clamp-3 text-sm leading-6 break-words text-slate-700 dark:text-slate-200">
+                {!! $snippet !!}
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/components/notifications/user-followed.blade.php
+++ b/resources/views/components/notifications/user-followed.blade.php
@@ -3,16 +3,45 @@
     'follower',
 ])
 
-<div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
-    <figure class="{{ $follower->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10 shrink-0 bg-slate-100 transition-opacity group-hover:opacity-90 dark:bg-slate-800">
+<div class="flex items-start gap-3 sm:gap-4">
+    <figure class="{{ $follower->is_company_verified ? 'rounded-2xl' : 'rounded-full' }} h-10 w-10 sm:h-12 sm:w-12 shrink-0 overflow-hidden border border-slate-200/70 bg-slate-100 transition-opacity group-hover:opacity-90 dark:border-slate-800/30 dark:bg-[#10182b]">
         <img
             src="{{ $follower->avatar_url }}"
             alt="{{ $follower->username }}"
-            class="{{ $follower->is_company_verified ? 'rounded-md' : 'rounded-full' }} h-10 w-10"
+            class="{{ $follower->is_company_verified ? 'rounded-2xl' : 'rounded-full' }} h-10 w-10 sm:h-12 sm:w-12"
         />
     </figure>
-    <p>
-        <span class="font-medium text-slate-950 dark:text-white">{{ '@' . $follower->username }}</span>
-        followed you
-    </p>
+
+    <div class="min-w-0 flex-1 py-0.5">
+        <div class="flex items-center justify-between gap-x-2">
+            <div class="flex min-w-0 flex-1 items-center gap-x-1.5 text-sm">
+                <p class="truncate font-medium text-slate-950 dark:text-white">{{ $follower->name }}</p>
+
+                @if ($follower->is_verified && $follower->is_company_verified)
+                    <x-icons.verified-company :color="$follower->right_color" class="h-3.5 w-3.5 shrink-0" />
+                @elseif ($follower->is_verified)
+                    <x-icons.verified :color="$follower->right_color" class="h-3.5 w-3.5 shrink-0" />
+                @endif
+
+                <p class="truncate text-slate-500 transition-colors group-hover:text-slate-600 dark:text-slate-400 dark:group-hover:text-slate-300">
+                    {{ '@'.$follower->username }}
+                </p>
+            </div>
+
+            <div class="flex shrink-0 items-center gap-2 text-[0.82rem] text-slate-500 dark:text-slate-400">
+                <time
+                    class="inline-flex cursor-help items-center whitespace-nowrap"
+                    title="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->isoFormat('ddd, D MMMM YYYY HH:mm') }}"
+                    datetime="{{ $notification->created_at->timezone(session()->get('timezone', 'UTC'))->toIso8601String() }}"
+                >
+                    {{
+                        $notification->created_at->timezone(session()->get('timezone', 'UTC'))
+                            ->diffForHumans(short: true)
+                    }}
+                </time>
+            </div>
+        </div>
+
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">followed you</p>
+    </div>
 </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -23,7 +23,7 @@
     </div>
 
     <div class="relative flex min-h-screen flex-col">
-        <div class="mx-auto flex w-full max-w-7xl flex-1 px-0 pb-28 lg:grid lg:pb-0 {{ $showRightRail ? 'lg:grid-cols-[18rem_minmax(0,1fr)_22.5rem]' : 'lg:grid-cols-[18rem_minmax(0,1fr)]' }}">
+        <div class="mx-auto flex w-full max-w-7xl flex-1 px-0 lg:grid {{ $showRightRail ? 'lg:grid-cols-[18rem_minmax(0,1fr)_22.5rem]' : 'lg:grid-cols-[18rem_minmax(0,1fr)]' }}">
             <aside class="lg:sticky lg:top-0 lg:flex lg:h-screen lg:flex-col">
                 @include('layouts.navigation')
             </aside>

--- a/resources/views/livewire/notifications/index.blade.php
+++ b/resources/views/livewire/notifications/index.blade.php
@@ -4,62 +4,58 @@
 
         @if ($notifications->count() > 0)
             <button
-                class="inline-flex items-center rounded-full border border-slate-200/70 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-950 dark:border-slate-800/30 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
+                class="inline-flex h-8 items-center justify-center rounded-full border border-slate-200/70 bg-white px-3 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-950 dark:border-slate-800/30 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
                 wire:click="ignoreAll('{{ now() }}')"
             >
-                Ignore all
+                <span>Ignore all</span>
             </button>
         @endif
     </div>
 
-    <div class="min-h-screen p-4 sm:p-6">
-        <div class="mb-20 flex flex-col gap-3">
-            @foreach ($notifications as $notification)
-                @if ($notification->type === 'App\Notifications\UserMentioned')
-                    @php
-                        /** @var Question|null $question */
-                        $question = $questions->get($notification->data['question_id'] ?? null);
-                    @endphp
+    <section class="space-y-0">
+        @foreach ($notifications as $notification)
+            @if ($notification->type === 'App\Notifications\UserMentioned')
+                @php
+                    /** @var Question|null $question */
+                    $question = $questions->get($notification->data['question_id'] ?? null);
+                @endphp
 
-                    @if ($question !== null)
-                        <x-notifications.item :notification="$notification">
-                            <x-notifications.mention :notification="$notification" :question="$question" />
-                        </x-notifications.item>
-                    @endif
-                @elseif (in_array($notification->type, ['App\Notifications\QuestionCreated', 'App\Notifications\QuestionAnswered'], true))
-                    @php
-                        /** @var Question|null $question */
-                        $question = $questions->get($notification->data['question_id'] ?? null);
-                    @endphp
-
-                    @if ($question !== null)
-                        <x-notifications.item :notification="$notification">
-                            <x-notifications.question
-                                :notification="$notification"
-                                :question="$question"
-                                :user="$user"
-                            />
-                        </x-notifications.item>
-                    @endif
-                @elseif ($notification->type === 'App\Notifications\UserFollowed')
-                    @php
-                        /** @var User|null $follower */
-                        $follower = $followers->get($notification->data['follower_id'] ?? null);
-                    @endphp
-
-                    @if ($follower !== null)
-                        <x-notifications.item :notification="$notification">
-                            <x-notifications.user-followed :notification="$notification" :follower="$follower" />
-                        </x-notifications.item>
-                    @endif
+                @if ($question !== null)
+                    <x-notifications.item :notification="$notification">
+                        <x-notifications.mention :notification="$notification" :question="$question" />
+                    </x-notifications.item>
                 @endif
-            @endforeach
+            @elseif (in_array($notification->type, ['App\Notifications\QuestionCreated', 'App\Notifications\QuestionAnswered'], true))
+                @php
+                    /** @var Question|null $question */
+                    $question = $questions->get($notification->data['question_id'] ?? null);
+                @endphp
 
-            @if ($notifications->hasPages())
-                <div class="mt-4">{{ $notifications->links() }}</div>
+                @if ($question !== null)
+                    <x-notifications.item :notification="$notification">
+                        <x-notifications.question :notification="$notification" :question="$question" :user="$user" />
+                    </x-notifications.item>
+                @endif
+            @elseif ($notification->type === 'App\Notifications\UserFollowed')
+                @php
+                    /** @var User|null $follower */
+                    $follower = $followers->get($notification->data['follower_id'] ?? null);
+                @endphp
+
+                @if ($follower !== null)
+                    <x-notifications.item :notification="$notification">
+                        <x-notifications.user-followed :notification="$notification" :follower="$follower" />
+                    </x-notifications.item>
+                @endif
             @endif
+        @endforeach
 
-            @if ($notifications->count() === 0)
+        @if ($notifications->hasPages())
+            <div class="p-4 sm:p-6">{{ $notifications->links() }}</div>
+        @endif
+
+        @if ($notifications->count() === 0)
+            <div class="p-4 sm:p-6">
                 <div class="flex min-h-96 items-center justify-center rounded-md border border-dashed border-slate-300/80 bg-slate-50/70 px-6 text-center dark:border-slate-700/80 dark:bg-slate-900/50">
                     <div>
                         <p class="text-lg font-medium text-slate-950 dark:text-white">No pending notifications.</p>
@@ -68,7 +64,7 @@
                         </p>
                     </div>
                 </div>
-            @endif
-        </div>
-    </div>
+            </div>
+        @endif
+    </section>
 </div>

--- a/resources/views/vendor/pagination/simple-tailwind.blade.php
+++ b/resources/views/vendor/pagination/simple-tailwind.blade.php
@@ -1,0 +1,35 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between gap-2">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <span class="inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-500 cursor-not-allowed dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400">
+                {!! __('pagination.previous') !!}
+            </span>
+        @else
+            <a
+                href="{{ $paginator->previousPageUrl() }}"
+                rel="prev"
+                wire:navigate
+                class="inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-700 transition duration-150 ease-in-out hover:bg-slate-100 hover:text-slate-900 focus:border-pink-500 focus:outline-none focus:ring ring-slate-300 active:bg-slate-100 active:text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:hover:text-white dark:active:bg-slate-700 dark:active:text-slate-300"
+            >
+                {!! __('pagination.previous') !!}
+            </a>
+        @endif
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a
+                href="{{ $paginator->nextPageUrl() }}"
+                rel="next"
+                wire:navigate
+                class="inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-700 transition duration-150 ease-in-out hover:bg-slate-100 hover:text-slate-900 focus:border-pink-500 focus:outline-none focus:ring ring-slate-300 active:bg-slate-100 active:text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:hover:text-white dark:active:bg-slate-700 dark:active:text-slate-300"
+            >
+                {!! __('pagination.next') !!}
+            </a>
+        @else
+            <span class="inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-500 cursor-not-allowed dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400">
+                {!! __('pagination.next') !!}
+            </span>
+        @endif
+    </nav>
+@endif


### PR DESCRIPTION
### What:

- [x] Improvement

### Description:

Redesigns the notifications screen to match the edge-to-edge layout of posts in the feed:

1. **Continuous Feed Layout**:
   - Removed bulky card boxes, borders, and margins in favor of a full-width stream divided by subtle border separators (`border-b border-slate-200/70 dark:border-slate-800/40`), mirroring feed threads.
2. **Post-Structure Alignment**:
   - Standardized layout with author avatar on the left, action subtitle (*"followed you"*, *"commented on your Answer:"*, etc.), clean relative timestamp on the right, and excerpt text below.
3. **Prevent Nested Anchor Tag DOM Splitting**:
   - Implemented Pinkary's Alpine `clickHandler` pattern (`data-parent="true"`, hidden `x-ref="parentLink"`) on notification items so inline `@mention` links inside notifications do not trigger illegal `<a>` tag DOM splitting in browsers.
4. **Mobile Spacing & Pagination Alignment**:
   - Removed redundant container bottom padding that created a 112px gap before the footer on mobile, and adjusted footer bottom padding to clear the fixed mobile bottom bar.
   - Kept standard Laravel simple-tailwind pagination structure while matching Pinkary's theme palette.

Part of Stack #896 (Layer 3 of 3, builds on PR #894).
