### PR TITLE
feat: use Livewire WithPagination for reactive notifications pagination

### DIFF
--- a/app/Livewire/Notifications/Index.php
+++ b/app/Livewire/Notifications/Index.php
@@ -14,9 +14,12 @@ use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Pagination\Paginator;
 use Illuminate\View\View;
 use Livewire\Component;
+use Livewire\WithPagination;
 
 final class Index extends Component
 {
+    use WithPagination;
+
     /**
      * Ignore all notifications.
      */

--- a/resources/views/vendor/livewire/simple-tailwind.blade.php
+++ b/resources/views/vendor/livewire/simple-tailwind.blade.php
@@ -12,21 +12,21 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
 
 <div>
     @if ($paginator->hasPages())
-        <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
+        <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between items-center gap-2">
             <span>
                 {{-- Previous Page Link --}}
                 @if ($paginator->onFirstPage())
-                    <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 dark:bg-gray-950 bg-gray-50 border border-slate-500 cursor-default leading-5 rounded-md select-none">
+                    <span class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-500 cursor-not-allowed select-none dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400">
                         {!! __('pagination.previous') !!}
                     </span>
                 @else
                     @if(method_exists($paginator,'getCursorName'))
-                        <button type="button" dusk="previousPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->previousCursor()->encode() }}" wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-pink-500 dark:bg-gray-950 bg-gray-50 border border-slate-500 leading-5 rounded-md hover:bg-pink-900/20 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:text-gray-700 transition ease-in-out duration-150">
+                        <button type="button" dusk="previousPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->previousCursor()->encode() }}" wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-700 transition duration-150 ease-in-out hover:bg-slate-100 hover:text-slate-900 focus:border-pink-500 focus:outline-none focus:ring ring-slate-300 active:bg-slate-100 active:text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:hover:text-white dark:active:bg-slate-700 dark:active:text-slate-300">
                                 {!! __('pagination.previous') !!}
                         </button>
                     @else
                         <button
-                            type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-pink-500 dark:bg-gray-950 bg-gray-50 border border-pink-500 leading-5 rounded-md hover:bg-pink-900/20 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:text-gray-700 transition ease-in-out duration-150">
+                            type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-700 transition duration-150 ease-in-out hover:bg-slate-100 hover:text-slate-900 focus:border-pink-500 focus:outline-none focus:ring ring-slate-300 active:bg-slate-100 active:text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:hover:text-white dark:active:bg-slate-700 dark:active:text-slate-300">
                                 {!! __('pagination.previous') !!}
                         </button>
                     @endif
@@ -37,16 +37,16 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     @if(method_exists($paginator,'getCursorName'))
-                        <button type="button" dusk="nextPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->nextCursor()->encode() }}" wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-pink-500 dark:bg-gray-950 bg-gray-50 border border-pink-500 leading-5 rounded-md hover:bg-pink-900/20 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:text-pink-500 transition ease-in-out duration-150">
+                        <button type="button" dusk="nextPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->nextCursor()->encode() }}" wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-700 transition duration-150 ease-in-out hover:bg-slate-100 hover:text-slate-900 focus:border-pink-500 focus:outline-none focus:ring ring-slate-300 active:bg-slate-100 active:text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:hover:text-white dark:active:bg-slate-700 dark:active:text-slate-300">
                                 {!! __('pagination.next') !!}
                         </button>
                     @else
-                        <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-pink-500 dark:bg-gray-950 bg-gray-50 border border-pink-500 leading-5 rounded-md hover:bg-pink-900/20 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:text-pink-500 transition ease-in-out duration-150">
+                        <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-700 transition duration-150 ease-in-out hover:bg-slate-100 hover:text-slate-900 focus:border-pink-500 focus:outline-none focus:ring ring-slate-300 active:bg-slate-100 active:text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:hover:text-white dark:active:bg-slate-700 dark:active:text-slate-300">
                                 {!! __('pagination.next') !!}
                         </button>
                     @endif
                 @else
-                    <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 dark:bg-gray-950 bg-gray-50 border border-slate-500 cursor-default leading-5 rounded-md select-none">
+                    <span class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium leading-5 text-slate-500 cursor-not-allowed select-none dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400">
                         {!! __('pagination.next') !!}
                     </span>
                 @endif


### PR DESCRIPTION
### What:

- [x] Improvement

### Description:

Switches notifications pagination from standard URL navigation (`wire:navigate`) to reactive Livewire pagination:

1. **Livewire `WithPagination` Trait**:
   - Added `Livewire\WithPagination` to `App\Livewire\Notifications\Index`.
   - Updated Livewire's pagination template (`resources/views/vendor/livewire/simple-tailwind.blade.php`) to use the clean slate theme colors instead of legacy pink buttons, matching site defaults.
   - Notifications now paginate reactively in-place without page transitions or reloads.

Part of Stack #896 (Layer 4 of 4, builds on PR #895).
