### PR TITLE
UI fixes

### DIFF
--- a/resources/views/bookmarks/index.blade.php
+++ b/resources/views/bookmarks/index.blade.php
@@ -1,10 +1,10 @@
 <x-app-layout>
-    <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+    <section class="flex flex-1 flex-col border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
         <div class="sticky -top-1 z-30 flex items-center justify-between border-b border-slate-200/70 bg-white px-6 py-4 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
             <h2 class="text-[2rem] font-semibold tracking-tight text-slate-950 dark:text-white">Bookmarks</h2>
         </div>
 
-        <div class="min-h-screen p-4 sm:p-6">
+        <div class="flex-1 p-4 sm:p-6">
             <livewire:bookmarks />
         </div>
     </section>

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -2,7 +2,7 @@
     <section
         data-current-channel-id="{{ $channel->id }}"
         data-current-channel-name="{{ $channel->name }}"
-        class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95"
+        class="flex flex-1 flex-col border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95"
     >
         <div
             class="sticky -top-1 z-30 flex items-center justify-between border-b border-slate-200/70 bg-white px-4 py-3.5 sm:bg-white/90 sm:px-6 sm:py-4 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95"
@@ -27,7 +27,7 @@
             </div>
         </div>
 
-        <div class="space-y-0">
+        <div class="flex flex-1 flex-col space-y-0">
             @auth
                 <div class="hidden border-b border-slate-200/70 px-4 py-4 sm:block dark:border-slate-800/30">
                     <livewire:questions.create
@@ -38,7 +38,7 @@
                 </div>
             @endauth
 
-            <div class="min-h-screen">
+            <div class="flex-1">
                 <livewire:channels.show :channel="$channel" />
             </div>
         </div>

--- a/resources/views/hashtag/show.blade.php
+++ b/resources/views/hashtag/show.blade.php
@@ -1,5 +1,5 @@
 <x-app-layout>
-    <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+    <section class="flex flex-1 flex-col border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
         <div class="sticky -top-1 z-30 flex flex-col gap-2 border-b border-slate-200/70 bg-white px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
             <div>
                 <p class="text-sm font-medium text-slate-500 dark:text-slate-400">Hashtag</p>
@@ -11,8 +11,8 @@
             <x-home-menu></x-home-menu>
         </div>
 
-        <div class="space-y-0">
-            <div>
+        <div class="flex flex-1 flex-col space-y-0">
+            <div class="flex-1">
                 <livewire:home.feed :hashtag="$hashtag" />
             </div>
         </div>

--- a/resources/views/home/feed.blade.php
+++ b/resources/views/home/feed.blade.php
@@ -1,5 +1,5 @@
 <x-app-layout>
-    <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+    <section class="flex flex-1 flex-col border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
         <div class="sticky -top-1 z-30 flex flex-col gap-2 border-b border-slate-200/70 bg-white px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
             <h2 class="hidden text-[2rem] font-semibold tracking-tight text-slate-950 sm:block dark:text-white">
                 Feed
@@ -8,14 +8,14 @@
             <x-home-menu></x-home-menu>
         </div>
 
-        <div class="space-y-0">
+        <div class="flex flex-1 flex-col space-y-0">
             @auth
                 <div class="hidden border-b border-slate-200/70 px-4 py-4 sm:block dark:border-slate-800/30">
                     <livewire:questions.create :toId="auth()->id()" />
                 </div>
             @endauth
 
-            <div>
+            <div class="flex-1">
                 <livewire:home.feed />
             </div>
         </div>

--- a/resources/views/home/following.blade.php
+++ b/resources/views/home/following.blade.php
@@ -1,5 +1,5 @@
 <x-app-layout>
-    <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+    <section class="flex flex-1 flex-col border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
         <div class="sticky -top-1 z-30 flex flex-col gap-2 border-b border-slate-200/70 bg-white px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
             <h2 class="hidden text-[2rem] font-semibold tracking-tight text-slate-950 sm:block dark:text-white">
                 Feed
@@ -8,13 +8,13 @@
             <x-home-menu></x-home-menu>
         </div>
 
-        <div class="space-y-0">
+        <div class="flex flex-1 flex-col space-y-0">
             @auth
                 <div class="hidden border-b border-slate-200/70 px-4 py-4 sm:block dark:border-slate-800/30">
                     <livewire:questions.create :toId="auth()->id()" />
                 </div>
 
-                <div>
+                <div class="flex-1">
                     <livewire:home.questions-following :focus-input="true" />
                 </div>
             @else

--- a/resources/views/home/trending-questions.blade.php
+++ b/resources/views/home/trending-questions.blade.php
@@ -1,5 +1,5 @@
 <x-app-layout>
-    <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+    <section class="flex flex-1 flex-col border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
         <div class="sticky -top-1 z-30 flex flex-col gap-2 border-b border-slate-200/70 bg-white px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
             <h2 class="hidden text-[2rem] font-semibold tracking-tight text-slate-950 sm:block dark:text-white">
                 Feed
@@ -8,14 +8,14 @@
             <x-home-menu></x-home-menu>
         </div>
 
-        <div class="space-y-0">
+        <div class="flex flex-1 flex-col space-y-0">
             @auth
                 <div class="hidden border-b border-slate-200/70 px-4 py-4 sm:block dark:border-slate-800/30">
                     <livewire:questions.create :toId="auth()->id()" />
                 </div>
             @endauth
 
-            <div>
+            <div class="flex-1">
                 <livewire:home.trending-questions :focus-input="true" />
             </div>
         </div>

--- a/resources/views/home/users.blade.php
+++ b/resources/views/home/users.blade.php
@@ -1,5 +1,5 @@
 <x-app-layout>
-    <div class="space-y-0">
+    <div class="flex flex-1 flex-col space-y-0">
         <section class="sticky top-[57px] z-30 border-r border-b border-slate-200/70 bg-white/90 px-4 py-4 backdrop-blur lg:top-0 dark:border-slate-800/30 dark:bg-[#07101f]/95">
             <div class="space-y-3">
                 <h2 class="text-[2rem] font-semibold tracking-tight text-slate-950 sm:text-[2.1rem] dark:text-white">
@@ -10,7 +10,7 @@
             </div>
         </section>
 
-        <section class="min-h-screen">
+        <section class="flex-1">
             <livewire:home.users :focus-input="true" />
         </section>
     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -23,12 +23,12 @@
     </div>
 
     <div class="relative flex min-h-screen flex-col">
-        <div class="mx-auto flex w-full max-w-7xl flex-1 px-0 lg:grid {{ $showRightRail ? 'lg:grid-cols-[18rem_minmax(0,1fr)_22.5rem]' : 'lg:grid-cols-[18rem_minmax(0,1fr)]' }}">
+        <div class="mx-auto flex w-full max-w-7xl flex-1 flex-col px-0 lg:grid {{ $showRightRail ? 'lg:grid-cols-[18rem_minmax(0,1fr)_22.5rem]' : 'lg:grid-cols-[18rem_minmax(0,1fr)]' }}">
             <aside class="lg:sticky lg:top-0 lg:flex lg:h-screen lg:flex-col">
                 @include('layouts.navigation')
             </aside>
 
-            <div class="min-w-0 flex-1 {{ $showDiscoverLayout ? 'lg:col-start-2' : '' }} {{ $showRightRail ? 'lg:pr-2' : '' }}">
+            <div class="flex min-w-0 flex-1 flex-col {{ $showDiscoverLayout ? 'lg:col-start-2' : '' }} {{ $showRightRail ? 'lg:pr-2' : '' }}">
                 @if ($showDiscoverLayout)
                     <form
                         x-data="{ query: @js($globalSearchQuery) }"
@@ -103,7 +103,7 @@
                     </div>
                 @endif
 
-                <main class="w-full">{{ $slot }}</main>
+                <main class="[&>*]:flex [&>*]:flex-1 [&>*]:flex-col flex w-full flex-1 flex-col">{{ $slot }}</main>
 
                 <x-image-lightbox />
             </div>

--- a/resources/views/livewire/feed.blade.php
+++ b/resources/views/livewire/feed.blade.php
@@ -1,5 +1,5 @@
-<div>
-    <section class="min-h-screen space-y-0">
+<div class="flex flex-1 flex-col">
+    <section class="flex-1 space-y-0">
         @forelse ($questions as $question)
             <div
                 wire:key="thread-{{ $question->id }}"

--- a/resources/views/livewire/home/questions-following.blade.php
+++ b/resources/views/livewire/home/questions-following.blade.php
@@ -1,5 +1,5 @@
-<div class="w-full text-slate-700 dark:text-slate-200">
-    <section class="min-h-screen space-y-0">
+<div class="flex w-full flex-1 flex-col text-slate-700 dark:text-slate-200">
+    <section class="flex-1 space-y-0">
         @forelse ($followingQuestions as $question)
             <div class="border-b border-slate-200 px-2 py-2 transition hover:bg-slate-50 dark:border-slate-700/50 dark:hover:bg-[#0a1325]">
                 <x-thread

--- a/resources/views/livewire/home/trending-questions.blade.php
+++ b/resources/views/livewire/home/trending-questions.blade.php
@@ -1,5 +1,5 @@
-<div class="w-full text-slate-700 dark:text-slate-200">
-    <section class="min-h-screen space-y-0">
+<div class="flex w-full flex-1 flex-col text-slate-700 dark:text-slate-200">
+    <section class="flex-1 space-y-0">
         @forelse ($trendingQuestions as $question)
             <div class="border-b border-slate-200 px-2 py-2 transition hover:bg-slate-50 dark:border-slate-700/50 dark:hover:bg-[#0a1325]">
                 <livewire:questions.show

--- a/resources/views/livewire/notifications/index.blade.php
+++ b/resources/views/livewire/notifications/index.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="flex flex-1 flex-col">
     <div class="sticky -top-1 z-30 flex items-center justify-between border-b border-slate-200/70 bg-white px-6 py-4 sm:bg-white/90 sm:py-6 sm:backdrop-blur dark:border-slate-800/30 dark:bg-[#07101f] dark:sm:bg-[#07101f]/95">
         <h2 class="text-[2rem] font-semibold tracking-tight text-slate-950 dark:text-white">Notifications</h2>
 
@@ -12,7 +12,7 @@
         @endif
     </div>
 
-    <section class="space-y-0">
+    <section class="flex-1 space-y-0">
         @foreach ($notifications as $notification)
             @if ($notification->type === 'App\Notifications\UserMentioned')
                 @php

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -1,5 +1,5 @@
 <x-app-layout>
-    <section class="border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+    <section class="flex flex-1 flex-col border-x border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
         <livewire:notifications-index />
     </section>
 </x-app-layout>

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,17 +1,17 @@
 <x-app-layout people-to-follow-context="profile" :people-to-follow-user-id="$user->id">
-    <div class="space-y-0 border-x border-slate-200 py-0 dark:border-slate-700/50">
+    <div class="flex flex-1 flex-col space-y-0 border-x border-slate-200 py-0 dark:border-slate-700/50">
         <section class="border-b border-slate-200 bg-white/80 p-4 sm:p-5 dark:border-slate-700/50 dark:bg-[#07101f]/95">
             <livewire:links :userId="$user->id" />
         </section>
 
-        <section class="border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+        <section class="flex flex-1 flex-col border-b border-slate-200 bg-white/80 dark:border-slate-700/50 dark:bg-[#07101f]/95">
             <div class="border-b border-slate-200 px-4 py-4 dark:border-slate-700/50">
                 <div class="border border-slate-200/70 bg-slate-50/80 p-4 dark:border-slate-800/30 dark:bg-[#0b1324]">
                     <livewire:questions.create :toId="$user->id" />
                 </div>
             </div>
 
-            <div>
+            <div class="flex-1">
                 <livewire:questions :userId="$user->id" />
             </div>
         </section>

--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -3,7 +3,11 @@
     :people-to-follow-user-id="$question->to_id"
     :people-to-follow-question-id="$question->id"
 >
-    <div class="py-0" x-data x-init="document.getElementById('q-{{ $question->id }}').scrollIntoView();">
+    <div
+        class="flex flex-1 flex-col py-0"
+        x-data
+        x-init="document.getElementById('q-{{ $question->id }}').scrollIntoView();"
+    >
         <section class="overflow-hidden border-x border-b border-slate-200 bg-white dark:border-slate-700/50 dark:bg-[#07101f]/95">
             <div class="flex px-6 py-5">
                 <a
@@ -27,7 +31,7 @@
             </div>
         </section>
 
-        <section class="border-x border-b border-slate-200 bg-white px-2 py-2 dark:border-slate-700/50 dark:bg-[#07101f]/95">
+        <section class="flex-1 border-x border-b border-slate-200 bg-white px-2 py-2 dark:border-slate-700/50 dark:bg-[#07101f]/95">
             @foreach ($parentQuestions as $parentQuestion)
                 <livewire:questions.show
                     :questionId="$parentQuestion->id"


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

Ensures that feed, notification, bookmark, channel, hashtag, question, and profile containers stretch all the way down to touch the footer, eliminating empty background gaps when feeds are empty or have few posts:

1. **Layout Flex Stretching (`layouts/app.blade.php`)**:
   - Made the center column and `<main>` flex containers (`flex flex-1 flex-col w-full [&>*]:flex [&>*]:flex-1 [&>*]:flex-col`) so that page content naturally stretches to fill the vertical space down to the footer.
   - Configured `flex flex-col lg:grid` on the layout wrapper so it also extends to the footer on mobile and tablet screens.

2. **Feeds & Empty States**:
   - Updated `home/following.blade.php`, `home/feed.blade.php`, `home/trending-questions.blade.php`, and `home/users.blade.php` to flex-stretch to the footer.
   - Replaced artificial `min-h-screen` overrides in Livewire feed views with `flex-1`, preventing unwanted overflow scrollbars on empty feeds.

3. **Notifications & Bookmarks**:
   - Configured `notifications/index.blade.php` and `livewire/notifications/index.blade.php` to stretch to the footer when there are no pending notifications.
   - Replaced `min-h-screen` in `bookmarks/index.blade.php` with `flex-1` so the empty bookmarks container touches the footer without forced viewport overflow.

4. **Channels, Hashtags, Questions & Profile**:
   - Updated container sections in `channels/show.blade.php`, `hashtag/show.blade.php`, `questions/show.blade.php`, and `profile/show.blade.php` with `flex-1` flexbox stretching.
