### PR TITLE
fix: restrict channel picker to root posts in edit composer

### DIFF
--- a/app/Livewire/Questions/Edit.php
+++ b/app/Livewire/Questions/Edit.php
@@ -49,7 +49,7 @@ final class Edit extends Component
         $question = Question::findOrFail($questionId);
         $rawAnswer = $question->getRawOriginal('answer');
         $this->answer = is_string($rawAnswer) ? $rawAnswer : '';
-        $this->channelId = $question->channel_id;
+        $this->channelId = blank($question->parent_id) ? $question->channel_id : null;
     }
 
     /**

--- a/resources/views/livewire/questions/edit.blade.php
+++ b/resources/views/livewire/questions/edit.blade.php
@@ -53,7 +53,7 @@
                             </button>
                         @endif
 
-                        @if ($question->isSharedUpdate())
+                        @if ($question->isSharedUpdate() && blank($question->parent_id))
                             <x-channel-picker />
                         @endif
                     @endif

--- a/tests/Http/PostChannelTest.php
+++ b/tests/Http/PostChannelTest.php
@@ -470,3 +470,54 @@ it('allows admins to post to an admin-only channel', function (): void {
 
     expect(Question::where('answer', 'Admin announcement')->first()?->channel_id)->toBe($channel->id);
 });
+
+it('does not show channel picker or update channel for replies', function (): void {
+    $user = User::factory()->create();
+    $channel = Channel::factory()->create(['questions_count' => 0]);
+
+    $parent = Question::factory()->sharedUpdate()->create([
+        'from_id' => $user->id,
+        'to_id' => $user->id,
+        'answer' => 'Parent update',
+        'answer_created_at' => now(),
+    ]);
+
+    $reply = Question::factory()->sharedUpdate()->create([
+        'from_id' => $user->id,
+        'to_id' => $user->id,
+        'answer' => 'Child reply',
+        'answer_created_at' => now(),
+        'parent_id' => $parent->id,
+        'root_id' => $parent->id,
+        'channel_id' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['questionId' => $reply->id])
+        ->assertSet('channelId', null)
+        ->assertDontSeeHtml('data-channel-picker')
+        ->set('answer', 'Edited reply')
+        ->set('channelId', $channel->id)
+        ->call('update')
+        ->assertHasNoErrors();
+
+    expect($reply->fresh()->channel_id)->toBeNull()
+        ->and($channel->fresh()->questions_count)->toBe(0);
+});
+
+it('shows channel picker for root shared updates', function (): void {
+    $user = User::factory()->create();
+    $channel = Channel::factory()->create();
+
+    $question = Question::factory()->sharedUpdate()->for($channel)->create([
+        'from_id' => $user->id,
+        'to_id' => $user->id,
+        'answer' => 'Root update',
+        'answer_created_at' => now(),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['questionId' => $question->id])
+        ->assertSet('channelId', $channel->id)
+        ->assertSeeHtml('data-channel-picker');
+});


### PR DESCRIPTION
Channel picker was shown when editing comments/replies that are shared updates (parent_id set), but channels should only be available for root posts.esources/views/livewire/questions/edit.blade.php: gate channel picker with blank(parent_id), matching Create composer and Edit backend guard.pp/Livewire/Questions/Edit.php: mount sets channelId to null for replies to avoid stale state.Tests: added reply-isolation coverage (picker hidden, tampered channelId ignored, counts unchanged) and root picker visibility check in tests/Http/PostChannelTest.php.46 tests pass (PostChannelTest + EditTest).