### PR TITLE
chore: update changelog for version 2.6.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Version 2.6.1
+> 12 September, 2026
+
+- Fixes feed, notifications, and bookmark containers not stretching to the footer.
+- Fixes channel picker showing when editing comments and replies; channels are now only available for root posts.
+- Internal improvements, dependency updates, and bug fixes.
+
 ## Version 2.6.0
 > 12 September, 2026
 


### PR DESCRIPTION
Adds 2.6.1 entry covering v2.6.0..main fixes: footer stretch fix (#898) and edit-composer channel picker root-only fix (#899). Follows existing patch entry format.